### PR TITLE
Fixed sizeof mistake in serialize.c example

### DIFF
--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -184,7 +184,7 @@ static void example1(void)
 	}
 	
 
-	retval = memcmp(cs, &servie, sizeof(&servie));
+	retval = memcmp(cs, &servie, sizeof(servie));
 	if (retval) {
 		printf("Not compared (%d)   -    FAILED\n", retval);
 		printf("%d   :  %d\n", servie.AcceptPause, cs->AcceptPause);


### PR DESCRIPTION
I noticed a mistake in examples/serialize.c, with Coverity scan tool. This is a very small bug, but decided to fix it to make it correct :)
