### PR TITLE
iniparser: `dictionary_set' must return a value.

### DIFF
--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -331,7 +331,7 @@ static int dictionary_set(dictionary * d, char * key, char * val)
     int         i ;
     unsigned    hash ;
 
-    if (d==NULL || key==NULL) return ;
+    if (d==NULL || key==NULL) return 1 ;
 
     /* Compute hash for this key */
     hash = dictionary_hash(key) ;
@@ -347,7 +347,7 @@ static int dictionary_set(dictionary * d, char * key, char * val)
                         free(d->val[i]);
                     d->val[i] = val ? strdup(val) : NULL ;
                     /* Value has been modified: return */
-                    return ;
+                    return 0 ;
                 }
             }
         }


### PR DESCRIPTION
The `dictionary_set' function is supposed to return an integer but in
two cases it was not leading to a build error when using Clang 3.4.
