### PR TITLE
introduce WsmanResourceNotFound exception for enumeration

### DIFF
--- a/src/cpp/Exception.h
+++ b/src/cpp/Exception.h
@@ -45,6 +45,8 @@ using namespace std;
 #define WSMAN_TCP_ERROR 13
 // failed to connect to server
 #define WSMAN_CONNECT_ERROR 14
+// resource not found
+#define WSMAN_RESOURCE_NOT_FOUND 15
 
 namespace WsmanExceptionNamespace
 {

--- a/src/cpp/OpenWsmanClient.cpp
+++ b/src/cpp/OpenWsmanClient.cpp
@@ -143,10 +143,7 @@ void OpenWsmanClient::Enumerate(const string &resourceUri, vector<string> &enumR
 	try
 	{
 		if(ResourceNotFound(cl, enum_response))
-		{
-			wsmc_options_destroy(options);
-			return;
-		}
+			throw WsmanResourceNotFound(resourceUri.c_str());
 	}
 	catch(WsmanSoapFault& e)
 	{
@@ -201,10 +198,7 @@ void OpenWsmanClient::Enumerate(const string & resourceUri, WsmanFilter & filter
 	try
 	{
 		if(ResourceNotFound(cl, enum_response))
-		{
-			wsmc_options_destroy(options);
-			return;
-		}
+			throw WsmanResourceNotFound(resourceUri.c_str());
 	}
 	catch(WsmanSoapFault& e)
 	{

--- a/src/cpp/WsmanClient.h
+++ b/src/cpp/WsmanClient.h
@@ -68,6 +68,17 @@ namespace WsmanClientNamespace
 		string GetFaultDetail() const throw() {return soapDetail;}
 	};
 
+        // Exception throw if a resource is not found
+        class WsmanResourceNotFound : public WsmanClientException
+        {
+        public:
+                WsmanResourceNotFound(const char *message)
+                    : WsmanClientException(message, WSMAN_RESOURCE_NOT_FOUND)
+                {
+                }
+                virtual ~WsmanResourceNotFound() throw() {}
+        };
+
 	typedef enum {
 		WSMAN_DELIVERY_PUSH = 0,
 		WSMAN_DELIVERY_PUSHWITHACK,


### PR DESCRIPTION
I added **WsmanResourceNotFound** class for better error handling. Current source code doesn't inform the client about an error, if some resouce can't be found; *nothing happens*.