### PR TITLE
fix markdown syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 After checking out the project from git, create a build directory
 with
+
     mkdir build
+
 cd into it
+
     cd build
     cmake ..
     make


### PR DESCRIPTION
Due to missing empty lines around the commands in build instruction section, those commands are squashed into single line during conversion to show README on the GitHub project page.