### PR TITLE
Remove unused min_threads option from config file and config file parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2.4.15
+- Features
+  - Ruby: Add Fault#to_s
+  - Ruby: Enable ClientOptions#properties=
+  - Cim: New config option "cim_client_cql' to select CQL query
+    identifier ('CQL' - default, 'DMTF:CQL' - standards-compliant)
+- Bugfixes
+  - Fix segfault in wsmc_add_property
+  - Fix memleak in xpath handling
+
 2.4.14
 - Features
   - Improved C++ bindings (Peter Hatina)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ following syntax:
     basic_password_file = /etc/openwsman/simple_auth.passwd
     enum_idle_timeout = 5000
 
-    min_threads = 1
     max_threads = 1
 
     #use_digest is OBSOLETED, see below.

--- a/bindings/ruby/helpers.h
+++ b/bindings/ruby/helpers.h
@@ -125,7 +125,7 @@ _add_str( VALUE key, VALUE value, hash_t *h )
 }
 
 
-/* add key,value VALUE pair to hash_t* as selector_entry*
+/* add key,value VALUE pair to hash_t* as kv_value_t*
  *  (used as callback for value2hash)
  */
 static int
@@ -134,13 +134,13 @@ _add_selector( VALUE key, VALUE value, hash_t *h )
     if (key != Qundef) {
 	const char *k = strdup( as_string( key ) );
 	if (!hash_lookup( h, k ) ) {
-            selector_entry *entry = u_malloc(sizeof(selector_entry));
+            kv_value_t *entry = u_malloc(sizeof(kv_value_t));
             entry->type = 0;
             if (TYPE(value) == T_ARRAY) {
               rb_raise( rb_eException, "Passing array parameter via invoke() still unsupported" );
             }
             else {
-              entry->entry.text = strdup(as_string( value ));
+              entry->value.text = strdup(as_string( value ));
             }
 	    if ( !hash_alloc_insert( h, k, entry ) ) {
 		rb_raise( rb_eException, "hash_alloc_insert failed" );
@@ -158,7 +158,7 @@ _add_selector( VALUE key, VALUE value, hash_t *h )
  *
  * valuetype - type of hash values
  *   0 - values are string (char *)
- *   1 - values are selector_entry *
+ *   1 - values are kv_value_t *
  * 
  */
 static hash_t *

--- a/bindings/ruby/tests/cim_process.rb
+++ b/bindings/ruby/tests/cim_process.rb
@@ -44,6 +44,10 @@ class WsmanTest < Test::Unit::TestCase
     uri = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_Process"
 
     result = client.enumerate( options, nil, uri )
+    if result.nil?
+      puts "client.enumerate failed with #{client.response_code}"
+      puts "#{client.last_error}:#{client.fault_string}"
+    end
     assert result
     if result.fault?
       fault = Openwsman::Fault.new result

--- a/bindings/wsman-client_opt.i
+++ b/bindings/wsman-client_opt.i
@@ -490,12 +490,12 @@ typedef struct {} client_opt_t;
       v = rb_hash_new();
       lnode_t *node = list_first($self->properties);
       while (node) {
-        client_property_t *property = (client_property_t *)node->list_data;
+        client_kv_t *property = (client_kv_t *)node->list_data;
         if (property->value.type == 0) {
-	  rb_hash_aset( v, makestring(property->key), makestring(property->value.entry.text));
+	  rb_hash_aset( v, makestring(property->key), makestring(property->value.value.text));
         }
         else {
-          rb_hash_aset( v, makestring(property->key), makestring(epr_to_string(property->value.entry.eprp)));
+          rb_hash_aset( v, makestring(property->key), makestring(epr_to_string(property->value.value.eprp)));
         }
         node = list_next($self->properties, node);
       }

--- a/etc/openwsman.conf
+++ b/etc/openwsman.conf
@@ -45,9 +45,8 @@ ssl_disabled_protocols = SSLv2 SSLv3
 # set these to enable basic authentication against a local datbase
 #basic_password_file = /etc/openwsman/simple_auth.passwd
 
-min_threads = 4
 max_threads = 0
-max_connections_per_thread=20
+max_connections_per_thread = 20
 #thread_stack_size=262144
 
 #use_digest is OBSOLETED, see below.

--- a/include/wsman-client-api.h
+++ b/include/wsman-client-api.h
@@ -196,11 +196,6 @@ typedef enum {
 		hash_t *options; /* for WSM_OPTION_SET */
 	} client_opt_t;
 
-        typedef struct {
-          char *key;
-          selector_entry value; /* either char* or epr_t */
-        } client_property_t;
-
 	struct _WsManFault {
 		const char *code;
 		const char *subcode;
@@ -208,7 +203,6 @@ typedef enum {
 		const char *fault_detail;
 	};
 	typedef struct _WsManFault WsManFault;
-
 
 
 	/**

--- a/include/wsman-epr.h
+++ b/include/wsman-epr.h
@@ -62,19 +62,11 @@ typedef struct {
 } ReferenceParameters;
 
 
-typedef struct {
+typedef struct epr_struct {
 	char * address;
 	ReferenceParameters refparams;
 	void * additionalParams;
 } epr_t;
-
-typedef struct {
-	int type;
-	union{
-		char *text;
-		epr_t *eprp;
-	} entry;
-} selector_entry;
 
 /* support for array values, all represented with the same key */	
 typedef struct {

--- a/include/wsman-types.h
+++ b/include/wsman-types.h
@@ -68,6 +68,26 @@ struct __WsXmlNs
 };
 typedef struct __WsXmlNs* WsXmlNsH;
 
+/*-----------------------------------------------*/
+
+typedef struct epr_struct epr_t;
+
+/* value of a key/value pair (-> client_kv_t)
+ * to represent either a value or an epr_t
+ */
+typedef struct {
+  int type; /* 0: char*, else epr_t* */
+  union{
+    char *text;
+    epr_t *eprp;
+  } value;
+} kv_value_t;
+
+/* generic client key/value pair */
+typedef struct {
+  char *key;
+  kv_value_t value; /* either char* or epr_t */
+} client_kv_t;
 
 #ifdef __cplusplus
 }

--- a/src/lib/wsman-filter.c
+++ b/src/lib/wsman-filter.c
@@ -81,7 +81,7 @@ static int filter_set(filter_t *filter, const char *dialect, const char *query, 
 		hnode_t        *hn;
 		hscan_t         hs;
 		Selector *p;
-		selector_entry *entry;
+		kv_value_t *entry;
 		filter->selectorset.count = hash_count(selectors);
 		filter->selectorset.selectors = u_malloc(sizeof(Selector)*
 			filter->selectorset.count);
@@ -90,15 +90,15 @@ static int filter_set(filter_t *filter, const char *dialect, const char *query, 
 		hash_scan_begin(&hs, selectors);
 		while ((hn = hash_scan_next(&hs))) {
 			p->name = u_strdup((char *)hnode_getkey(hn));
-			entry = (selector_entry *)hnode_get(hn);
+			entry = (kv_value_t *)hnode_get(hn);
 			if(entry->type == 1) {
 				p->type = 1;
-				p->value = (char *)epr_copy(entry->entry.eprp);
+				p->value = (char *)epr_copy(entry->value.eprp);
 				debug("key=%s value=%p(nested epr)",
 					(char *) hnode_getkey(hn), p->value);
 			} else {
 				p->type = 0;
-				p->value = u_strdup(entry->entry.text);
+				p->value = u_strdup(entry->value.text);
 				debug("key=%s value=%s",
 					(char *) hnode_getkey(hn), p->value);
 			}

--- a/src/plugins/cim/sfcc-interface.c
+++ b/src/plugins/cim/sfcc-interface.c
@@ -506,12 +506,12 @@ char *
 cim_get_namespace_selector(hash_t * keys)
 {
 	char *cim_namespace = NULL;
-	selector_entry *sentry = NULL;
+	kv_value_t *sentry = NULL;
 	hnode_t *hn = hash_lookup(keys, (char *) CIM_NAMESPACE_SELECTOR);
 	if (hn) {
-		sentry = (selector_entry *) hnode_get(hn);
+		sentry = (kv_value_t *) hnode_get(hn);
 		if(sentry->type == 1) return NULL;
-		cim_namespace = sentry->entry.text;
+		cim_namespace = sentry->value.text;
 		hash_delete(keys, hn);
 		hnode_destroy(hn);
 		u_free(sentry);
@@ -611,9 +611,9 @@ cim_add_args(CimClientInfo * client, CMPIObjectPath *op,
 		argnode = list_first(arglist);
 		for (ii = 0; ii < listcount; ii++) {
 			CMPIValue value;
-			selector_entry *sentry;
+			kv_value_t *sentry;
 			node_val = (methodarglist_t *)argnode->list_data;
-			sentry = (selector_entry *)node_val->data;
+			sentry = (kv_value_t *)node_val->data;
 			if (0 < node_val->arraycount) {
 				CMPIArray *arraydata = NULL;
 				lnode_t *t_anode = argnode;
@@ -625,7 +625,7 @@ cim_add_args(CimClientInfo * client, CMPIObjectPath *op,
 				for (kk = 1; kk < node_val->arraycount; kk++) {
 					t_anode = list_next(arglist, t_anode);
 					if (NULL != t_anode) {
-						selector_entry *t_sentry = (selector_entry *)((methodarglist_t *)t_anode->list_data)->data;
+						kv_value_t *t_sentry = (kv_value_t *)((methodarglist_t *)t_anode->list_data)->data;
 						char *key = ((methodarglist_t *)t_anode->list_data)->key;
 						debug(" %s[0] = %d, %s[%d] = %d", key, sentry->type, key, kk, t_sentry->type);	
 						if (sentry->type != t_sentry->type) {
@@ -642,19 +642,19 @@ cim_add_args(CimClientInfo * client, CMPIObjectPath *op,
 				for (jj = 0; jj < node_val->arraycount; jj++) {
 					debug("cim_add_args: array %u object: %p", jj, sentry);
 					if (0 != arraytype) {
-						value.ref = cim_epr_to_objectpath(client, sentry->entry.eprp);
+						value.ref = cim_epr_to_objectpath(client, sentry->value.eprp);
 						if (value.ref == NULL) {
 						        res = 1;
 							goto error;
 						}
 						CMSetArrayElementAt(arraydata, jj, &value, CMPI_ref);
 					} else {
-						value.string = native_new_CMPIString((char *)sentry->entry.text, NULL);
+						value.string = native_new_CMPIString((char *)sentry->value.text, NULL);
 						CMSetArrayElementAt(arraydata, jj, &value, CMPI_string);
 					}
 					argnode = list_next(arglist, argnode);
 					if (NULL != argnode)
-						sentry = (selector_entry *)((methodarglist_t *)argnode->list_data)->data;
+						sentry = (kv_value_t *)((methodarglist_t *)argnode->list_data)->data;
 				}
 				value.array = arraydata;
 				if (0 != arraytype)
@@ -665,17 +665,17 @@ cim_add_args(CimClientInfo * client, CMPIObjectPath *op,
 			} else {
 				debug("cim_add_args: single key: %s type: %u", node_val->key, sentry->type);
 				if (0 != sentry->type) {
-					epr_t *eprp = sentry->entry.eprp;
+					epr_t *eprp = sentry->value.eprp;
 					if (eprp == NULL) {
 						res = 1;
 						break;
 					}
 					debug("epr_t: selectorcount: %u", eprp->refparams.selectorset.count);
-					value.ref = cim_epr_to_objectpath(client, sentry->entry.eprp);
+					value.ref = cim_epr_to_objectpath(client, sentry->value.eprp);
 					CMAddArg(argsin, node_val->key, &value, CMPI_ref);
 				} else {
-					debug("text: %s", sentry->entry.text);
-					CMAddArg(argsin, node_val->key, sentry->entry.text, CMPI_chars);
+					debug("text: %s", sentry->value.text);
+					CMAddArg(argsin, node_val->key, sentry->value.text, CMPI_chars);
 				}
 				argnode = list_next(arglist, argnode);
 			}
@@ -694,20 +694,20 @@ cim_add_keys(CMPIObjectPath * objectpath, hash_t * keys)
 {
 	hscan_t hs;
 	hnode_t *hn;
-	selector_entry *sentry;
+	kv_value_t *sentry;
 	if (keys == NULL) {
 		return;
 	}
 	hash_scan_begin(&hs, keys);
 	while ((hn = hash_scan_next(&hs))) {
-		sentry = (selector_entry *)hnode_get(hn);
-		debug("in cim_add_keys: key: %s, text: %s", hnode_getkey(hn), sentry->entry.text);
+		sentry = (kv_value_t *)hnode_get(hn);
+		debug("in cim_add_keys: key: %s, text: %s", hnode_getkey(hn), sentry->value.text);
 		if(sentry->type == 0)
 			CMAddKey(objectpath, (char *) hnode_getkey(hn),
-					sentry->entry.text, CMPI_chars);
+					sentry->value.text, CMPI_chars);
 		else {
 			CMPIValue value;
-			value.ref = cim_epr_to_objectpath(NULL, sentry->entry.eprp);;
+			value.ref = cim_epr_to_objectpath(NULL, sentry->value.eprp);;
 			if (NULL != value.ref) {
 				CMAddKey(objectpath, (char *) hnode_getkey(hn),
 					&value, CMPI_ref);
@@ -843,10 +843,10 @@ cim_verify_keys(CMPIObjectPath * objectpath, hash_t * keys,
 			debug("unexpected selectors");
 			break;
 		}
-		selector_entry *sentry = (selector_entry*)hnode_get(hn);
+		kv_value_t *sentry = (kv_value_t*)hnode_get(hn);
 		if(sentry->type == 0) {
 			cv = value2Chars(data.type, &data.value);
-			if(cv != NULL && strcmp(cv, sentry->entry.text) == 0) {
+			if(cv != NULL && strcmp(cv, sentry->value.text) == 0) {
 				statusP->fault_code = WSMAN_RC_OK;
 				statusP->fault_detail_code = WSMAN_DETAIL_OK;
 				u_free(cv);
@@ -854,14 +854,14 @@ cim_verify_keys(CMPIObjectPath * objectpath, hash_t * keys,
 			else {
 				statusP->fault_code = WSA_DESTINATION_UNREACHABLE;
 				statusP->fault_detail_code = WSMAN_DETAIL_INVALID_RESOURCEURI;
-				debug("selector '%s', value: [ %s ] not matched", hnode_getkey(hn), sentry->entry.text);
+				debug("selector '%s', value: [ %s ] not matched", hnode_getkey(hn), sentry->value.text);
 			        debug("data.type 0x%04x, cv '%s'", data.type, cv?cv:"<NULL>");
 				u_free(cv);
 				break;
 			}
 		}
 		else {
-			CMPIObjectPath *objectpath_epr = cim_epr_to_objectpath(NULL, sentry->entry.eprp);
+			CMPIObjectPath *objectpath_epr = cim_epr_to_objectpath(NULL, sentry->value.eprp);
 			CMPIObjectPath *objectpath_epr2 = CMClone(data.value.ref, NULL);
 			if (cim_opcmp(objectpath_epr2, objectpath_epr) == 0) {
 				statusP->fault_code = WSMAN_RC_OK;

--- a/src/server/wsmand-daemon.c
+++ b/src/server/wsmand-daemon.c
@@ -95,7 +95,6 @@ static char *custom_identify_file = NULL;
 static char *basic_authenticator_arg = NULL;
 static char *basic_authenticator = DEFAULT_BASIC_AUTH;
 static int max_threads = 1;
-static int min_threads = 4;
 static unsigned long enumIdleTimeout = 100;
 static char *thread_stack_size="0";
 static int max_connections_per_thread=20;
@@ -201,7 +200,6 @@ int wsmand_read_config(dictionary * ini)
 	basic_authenticator_arg =
 	    iniparser_getstr(ini, "server:basic_authenticator_arg");
 	log_location = iniparser_getstr(ini, "server:log_location");
-	min_threads = iniparser_getint(ini, "server:min_threads", 1);
 	max_threads = iniparser_getint(ini, "server:max_threads", 0);
 	uri_subscription_repository = iniparser_getstring(ini, "server:subs_repository", DEFAULT_SUBSCRIPTION_REPOSITORY);
         max_connections_per_thread = iniparser_getint(ini, "server:max_connections_per_thread", iniparser_getint(ini, "server:max_connextions_per_thread", 20));
@@ -353,11 +351,6 @@ char *wsmand_options_get_ssl_disabled_protocols(void)
 int wsmand_options_get_digest(void)
 {
 	return use_digest;
-}
-
-int wsmand_options_get_min_threads(void)
-{
-	return min_threads;
 }
 
 

--- a/src/server/wsmand-daemon.h
+++ b/src/server/wsmand-daemon.h
@@ -81,7 +81,6 @@ int wsmand_options_get_digest(void);
 char *wsmand_options_get_digest_password_file(void);
 char *wsmand_options_get_basic_password_file(void);
 char *wsmand_options_get_service_path(void);
-int wsmand_options_get_min_threads(void);
 int wsmand_options_get_max_threads(void);
 char *wsmand_default_basic_authenticator(void);
 char *wsmand_option_get_basic_authenticator(void);

--- a/tests/client/test_selectorfilter.c
+++ b/tests/client/test_selectorfilter.c
@@ -87,12 +87,12 @@ int main(int argc, char** argv)
 	hash_t *selectors_new = hash_create2(HASHCOUNT_T_MAX, 0, 0);
 	hnode_t        *hn;
 	hscan_t         hs;
-	selector_entry *entry;
+	kv_value_t     *entry;
 	hash_scan_begin(&hs, selectors);
 	while ((hn = hash_scan_next(&hs))) {
-		entry = u_malloc(sizeof(selector_entry));
+		entry = u_malloc(sizeof(kv_value_t));
 		entry->type = 0;
-		entry->entry.text = (char *)hnode_get(hn);
+		entry->value.text = (char *)hnode_get(hn);
 		hash_alloc_insert(selectors_new, hnode_getkey(hn), entry);
 	}
 	filter_t *filter = filter_create_selector(selectors_new);

--- a/tests/epr/test_epr.c
+++ b/tests/epr/test_epr.c
@@ -8,16 +8,16 @@
 static void test_serialize1(void)
 {
 	hash_t *selectors_filter = hash_create(HASHCOUNT_T_MAX, 0, 0);
-	selector_entry *entry1 = NULL;
-	entry1 = u_malloc(sizeof(selector_entry)*4);
+	kv_value_t *entry1 = NULL;
+	entry1 = u_malloc(sizeof(kv_value_t)*4);
 	entry1[0].type = 0;
-	entry1[0].entry.text = "OperatingSystemFilter0";
+	entry1[0].value.text = "OperatingSystemFilter0";
 	entry1[1].type = 0;
-        entry1[1].entry.text = "localhost.localdomain";
+        entry1[1].value.text = "localhost.localdomain";
 	entry1[2].type = 0;
-        entry1[2].entry.text = "CIM_IndicationFilter";
+        entry1[2].value.text = "CIM_IndicationFilter";
 	entry1[3].type = 0;
-        entry1[3].entry.text = "CIM_ComputerSystem";
+        entry1[3].value.text = "CIM_ComputerSystem";
 	hash_alloc_insert(selectors_filter, "Name", &entry1[0]);
 	hash_alloc_insert(selectors_filter, "SystemName", &entry1[1]);
 	hash_alloc_insert(selectors_filter, "CreationClassName", &entry1[2]);
@@ -29,15 +29,15 @@ static void test_serialize1(void)
         }
 
 	hash_t *selectors_handler = hash_create(HASHCOUNT_T_MAX, 0, 0);
-	selector_entry *entry2 = u_malloc(sizeof(selector_entry)*4);
+	kv_value_t *entry2 = u_malloc(sizeof(kv_value_t)*4);
 	entry2[0].type = 0;
-        entry2[0].entry.text = "OperatingSystemHandler0";
+        entry2[0].value.text = "OperatingSystemHandler0";
         entry2[1].type = 0;
-        entry2[1].entry.text = "localhost.localdomain";
+        entry2[1].value.text = "localhost.localdomain";
         entry2[2].type = 0;
-        entry2[2].entry.text = "CIM_IndicationHandlerCIMXML";
+        entry2[2].value.text = "CIM_IndicationHandlerCIMXML";
         entry2[3].type = 0;
-        entry2[3].entry.text = "CIM_ComputerSystem";
+        entry2[3].value.text = "CIM_ComputerSystem";
 	hash_alloc_insert(selectors_handler, "Name", &entry2[0]);
         hash_alloc_insert(selectors_handler, "SystemName", &entry2[1]);
         hash_alloc_insert(selectors_handler, "CreationClassName", &entry2[2]);
@@ -49,12 +49,12 @@ static void test_serialize1(void)
 	}
 
 	hash_t *selectors_subscription =  hash_create(HASHCOUNT_T_MAX, 0, 0);
-        selector_entry *entry3 = NULL;
-        entry3 = u_malloc(sizeof(selector_entry)*2);
+        kv_value_t *entry3 = NULL;
+        entry3 = u_malloc(sizeof(kv_value_t)*2);
         entry3[0].type = 1;
-        entry3[0].entry.eprp = epr_filter;
+        entry3[0].value.eprp = epr_filter;
         entry3[1].type = 1;
-        entry3[1].entry.eprp = epr_handler;
+        entry3[1].value.eprp = epr_handler;
         hash_alloc_insert(selectors_subscription, "Filter", &entry3[1]);
 	hash_alloc_insert(selectors_subscription, "Handler", &entry3[1]);
 	epr_t *epr_subscription = epr_create("http://schema.omc-project.org/wbem/wscim/1/cim-schema/2/CIM_IndicationSubscription", selectors_subscription, NULL);

--- a/tests/filter/test_filter.c
+++ b/tests/filter/test_filter.c
@@ -7,18 +7,18 @@
 static void serialize_filter1(void)
 {
 	hash_t *selectors = hash_create(HASHCOUNT_T_MAX, 0, 0);
-	selector_entry *entry1 = NULL;
-	entry1 = u_malloc(sizeof(selector_entry)*5);
+	kv_value_t *entry1 = NULL;
+	entry1 = u_malloc(sizeof(kv_value_t)*5);
 	entry1[0].type = 0;
-	entry1[0].entry.text = "OperatingSystemFilter0";
+	entry1[0].value.text = "OperatingSystemFilter0";
 	entry1[1].type = 0;
-        entry1[1].entry.text = "localhost.localdomain";
+        entry1[1].value.text = "localhost.localdomain";
 	entry1[2].type = 0;
-        entry1[2].entry.text = "CIM_IndicationFilter";
+        entry1[2].value.text = "CIM_IndicationFilter";
 	entry1[3].type = 0;
-        entry1[3].entry.text = "CIM_ComputerSystem";
+        entry1[3].value.text = "CIM_ComputerSystem";
 	entry1[4].type = 0;
-	entry1[4].entry.text = "root/interop";
+	entry1[4].value.text = "root/interop";
 	hash_alloc_insert(selectors, "Name", &entry1[0]);
 	hash_alloc_insert(selectors, "SystemName", &entry1[1]);
 	hash_alloc_insert(selectors, "CreationClassName", &entry1[2]);
@@ -71,16 +71,16 @@ static void serialize_filter2(void)
 static void serialize_filter3(void)
 {
 	hash_t *selectors = hash_create(HASHCOUNT_T_MAX, 0, 0);
-        selector_entry *entry1 = NULL;
-        entry1 = u_malloc(sizeof(selector_entry)*4);
+        kv_value_t *entry1 = NULL;
+        entry1 = u_malloc(sizeof(kv_value_t)*4);
         entry1[0].type = 0;
-        entry1[0].entry.text = "OperatingSystemFilter0";
+        entry1[0].value.text = "OperatingSystemFilter0";
         entry1[1].type = 0;
-        entry1[1].entry.text = "localhost.localdomain";
+        entry1[1].value.text = "localhost.localdomain";
         entry1[2].type = 0;
-        entry1[2].entry.text = "CIM_IndicationFilter";
+        entry1[2].value.text = "CIM_IndicationFilter";
         entry1[3].type = 0;
-        entry1[3].entry.text = "CIM_ComputerSystem";
+        entry1[3].value.text = "CIM_ComputerSystem";
         hash_alloc_insert(selectors, "Name", &entry1[0]);
         hash_alloc_insert(selectors, "SystemName", &entry1[1]);
         hash_alloc_insert(selectors, "CreationClassName", &entry1[2]);


### PR DESCRIPTION
It should be safe - even if min_threads is still present in config file (e.g. old and untouched config), it should be ignored and will break nothing.