### PR TITLE
Python bindings - add functions to wrap fopen() and fclose().

### DIFF
--- a/bindings/openwsman.i
+++ b/bindings/openwsman.i
@@ -182,6 +182,9 @@ SWIGINTERNINLINE SV *SWIG_From_double  SWIG_PERL_DECL_ARGS_1(double value);
 
 #if defined(SWIGPYTHON)
 %module pywsman
+/* Wrap file operations, as Python's native ones are incompatible */
+FILE *fopen(char *, char *);
+void fclose(FILE *f);
 #endif
 
 #if defined(SWIGPERL)


### PR DESCRIPTION
In using the Python bindings, I've noticed there doesn't seem to be a way to interface with the library's C file descriptors, eg. in `Client().set_dumpfile()`.

Both the native `open()` and the lower-level `os.fdopen()` raise TypeErrors  when used with the above function.

This patch implements wrappers around `fopen()` and `fclose()`, which circumvents this issue.

