### PR TITLE
Add shebang line to winrs

### DIFF
--- a/examples/winrs.rb
+++ b/examples/winrs.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+#
 # winrs.rb
 #
 # Windows Remote Shell


### PR DESCRIPTION
Without the shebang line, bash considers this to be a shell script:

```
$ winrs
/usr/bin/winrs: line 9: require: command not found
/usr/bin/winrs: line 10: require: command not found
/usr/bin/winrs: line 11: require: command not found
/usr/bin/winrs: line 13: def: command not found
/usr/bin/winrs: line 54: syntax error near unexpected token `('
/usr/bin/winrs: line 54: `  opts = GetoptLong.new('
```