### PR TITLE
Fix SSL library usage is not thread safe

### DIFF
--- a/src/server/wsmand-listener.c
+++ b/src/server/wsmand-listener.c
@@ -83,6 +83,10 @@
 #endif
 #include <sys/socket.h>
 
+/* SSL thread safe */
+#include <openssl/crypto.h>
+static pthread_mutex_t *lock_cs;
+static long *lock_count;
 
 static pthread_mutex_t shttpd_mutex;
 static pthread_cond_t shttpd_cond;
@@ -106,6 +110,50 @@ typedef struct {
 char * gss_decrypt(struct shttpd_arg *arg, char *data, int len);
 int gss_encrypt(struct shttpd_arg *arg, char *input, int inlen, char **output, int *outlen);
 #endif
+
+/* SSL thread safe */
+void pthreads_locking_callback(int mode, int type, char *file, int line) {
+	if (mode & CRYPTO_LOCK) {
+		pthread_mutex_lock(&(lock_cs[type]));
+		lock_count[type]++;
+	}
+	else {
+		pthread_mutex_unlock(&(lock_cs[type]));
+	}
+}
+
+unsigned long pthreads_thread_id(void) {
+	unsigned long ret;
+
+	ret = (unsigned long)pthread_self();
+	return(ret);
+}
+
+void thread_setup(void) {
+	int i;
+
+	lock_cs = OPENSSL_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
+	lock_count = OPENSSL_malloc(CRYPTO_num_locks() * sizeof(long));
+	for (i = 0; i < CRYPTO_num_locks(); i++) {
+		lock_count[i] = 0;
+		pthread_mutex_init(&(lock_cs[i]), NULL);
+	}
+
+	CRYPTO_set_id_callback((unsigned long (*)())pthreads_thread_id);
+	CRYPTO_set_locking_callback((void (*)())pthreads_locking_callback);
+}
+
+void thread_cleanup(void) {
+	int i;
+
+	CRYPTO_set_locking_callback(NULL);
+	for (i = 0; i < CRYPTO_num_locks(); i++) {
+		pthread_mutex_destroy(&(lock_cs[i]));
+	}
+
+	OPENSSL_free(lock_cs);
+	OPENSSL_free(lock_count);
+}
 
 /* Check HTTP headers */
 static
@@ -723,6 +771,10 @@ WsManListenerH *wsmand_start_server(dictionary * ini)
 
 	if (wsman_setup_thread(&pattrs) == 0 )
 		return listener;
+
+	/* SSL thread safe */
+	thread_setup();
+
 	pthread_create(&tid, &pattrs, wsman_server_auxiliary_loop_thread, cntx);
 
 #ifdef ENABLE_EVENTING_SUPPORT
@@ -749,5 +801,9 @@ WsManListenerH *wsmand_start_server(dictionary * ini)
 		}
                 shttpd_add_socket(thread->ctx, sock, use_ssl);
         }
+
+	/* SSL thread safe */
+	thread_cleanup();
+
         return listener;
 }


### PR DESCRIPTION
Openwsman randomly crashes with BT like:
#0  0x00007f95523a45f7 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007f95523a5ce8 in __GI_abort () at abort.c:90
#2  0x00007f954decc208 in rb_bug (fmt=fmt@entry=0x7f954e012ebf "Segmentation fault") at error.c:314
#3  0x00007f954df795b6 in sigsegv (sig=<optimized out>, info=<optimized out>, ctx=<optimized out>) at signal.c:679
#4  <signal handler called>
#5  freelist_extract (for_read=for_read@entry=1, sz=sz@entry=17736, ctx=<optimized out>, ctx=<optimized out>) at s3_both.c:701
#6  0x00007f955316c373 in ssl3_setup_read_buffer (s=s@entry=0x7f9555886df0) at s3_both.c:770
#7  0x00007f955316c4d9 in ssl3_setup_buffers (s=0x7f9555886df0) at s3_both.c:827
#8  0x00007f955316da7d in ssl23_get_client_hello (s=0x7f9555886df0) at s23_srvr.c:266
#9  0x00007f955316e108 in ssl23_accept (s=0x7f9555886df0) at s23_srvr.c:210
#10 0x00007f95541f11ce in ssl_handshake (stream=stream@entry=0x7f95558dd4b8) at /usr/src/debug/openwsman-2.3.6/src/server/shttpd/io_ssl.c:39
#11 0x00007f95541ed0e6 in shttpd_add_socket (ctx=0x7f9555884530, sock=sock@entry=14, is_ssl=is_ssl@entry=1) at /usr/src/debug/openwsman-2.3.6/src/server/shttpd/shttpd.c:768
#12 0x00007f95541f443b in wsmand_start_server (ini=ini@entry=0x7f95556f0030) at /usr/src/debug/openwsman-2.3.6/src/server/wsmand-listener.c:750
#13 0x00007f95541eb866 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/openwsman-2.3.6/src/server/wsmand.c:295 

This patch makes usage of openssl thread safe and avoids this kind of crashes. It's based on examples from openssl upstream tarball:
crypto/threads/mttest.c

Also see:
https://www.openssl.org/docs/manmaster/crypto/threads.html