### PR TITLE
Make deprecation of autoconf/automake more visible

### DIFF
--- a/autoconfiscate.sh
+++ b/autoconfiscate.sh
@@ -1,8 +1,18 @@
-#!/bin/sh 
+#!/bin/sh
 
-echo "*** Autoconf/automake is deprecated for Openwsman"
-echo "*** and might not fully work."
-echo "*** Use cmake instead !"
+cat <<EOS >&2
+*** Autoconf/automake is deprecated for Openwsman and might not fully work.
+*** Please use CMake instead!
+
+EOS
+
+if [ "$1" != "--ignore-deprecation-warning" ]; then
+  cat <<EOS >&2
+*** To ignore this warning and proceed regardless, re-run as follows:
+***   $0 --ignore-deprecation-warning
+EOS
+  exit 1
+fi
 
 UNAME=`uname`
 


### PR DESCRIPTION
Print the error/warning message to standard error and require the user of the script to pass an additional argument to get past the warning message, making it clearer that the autotools build system is deprecated and building with CMake is strongly preferred.

This is a follow-up to #88.

New standard behavior (exits with a non-zero exit code):

```
$ ./autoconfiscate.sh
*** Autoconf/automake is deprecated for Openwsman and might not fully work.
*** Please use CMake instead!

*** To ignore this warning and proceed regardless, re-run as follows:
***   ./autoconfiscate.sh --ignore-deprecation-warning
```

If invoked with the option, will still print the first part of the message and then proceed as before.