### PR TITLE
Add missing shttpd header file

### DIFF
--- a/src/server/shttpd/defs.h
+++ b/src/server/shttpd/defs.h
@@ -18,7 +18,7 @@
 #include "io.h"
 #include "md5.h"
 #include "u/libu.h"
-#include "config.h"
+#include "shttpd_config.h"
 #include "shttpd.h"
 
 #define	NELEMS(ar)	(sizeof(ar) / sizeof(ar[0]))

--- a/src/server/shttpd/shttpd_config.h
+++ b/src/server/shttpd/shttpd_config.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2004-2005 Sergey Lyubka <valenok@gmail.com>
+ * All rights reserved
+ *
+ * "THE BEER-WARE LICENSE" (Revision 42):
+ * Sergey Lyubka wrote this file.  As long as you retain this notice you
+ * can do whatever you want with this stuff. If we meet some day, and you think
+ * this stuff is worth it, you can buy me a beer in return.
+ */
+
+#ifndef CONFIG_HEADER_DEFINED
+#define	CONFIG_HEADER_DEFINED
+
+#define	SHTTPD_VERSION	"1.42"		/* Version			*/
+#define	CONFIG_FILE	"shttpd.conf"	/* Configuration file		*/
+#define	HTPASSWD	".htpasswd"	/* Passwords file name		*/
+#define	URI_MAX		16384		/* Default max request size	*/
+#define	LISTENING_PORTS	"80"		/* Default listening ports	*/
+#define	INDEX_FILES	"index.html,index.htm,index.php,index.cgi"
+#define	CGI_EXT		"cgi,pl,php"	/* Default CGI extensions	*/
+#define	SSI_EXT		"shtml,shtm"	/* Default SSI extensions	*/
+#define	REALM		"mydomain.com"	/* Default authentication realm	*/
+#define	DELIM_CHARS	","		/* Separators for lists		*/
+#define	EXPIRE_TIME	3600		/* Expiration time, seconds	*/
+#define	ENV_MAX		4096		/* Size of environment block	*/
+#define	CGI_ENV_VARS	64		/* Maximum vars passed to CGI	*/
+#define	SERVICE_NAME	"SHTTPD " VERSION	/* NT service name	*/
+
+#endif /* CONFIG_HEADER_DEFINED */


### PR DESCRIPTION
I just noticed that one header file for shttpd is missing (because its name was "config.h", included in .gitignore). This commit fixes it and renames the header to make it less confusing.