### PR TITLE
Expect 1 from SSL_CTX_set_cipher_list(), not 0

### DIFF
--- a/src/server/shttpd/shttpd.c
+++ b/src/server/shttpd/shttpd.c
@@ -1543,7 +1543,7 @@ set_ssl(struct shttpd_ctx *ctx, const char *pem)
 
 	if (ssl_cipher_list) {
           int rc = SSL_CTX_set_cipher_list(CTX, ssl_cipher_list);
-          if (rc != 0) {
+          if (rc != 1) {
             _shttpd_elog(E_LOG, NULL, "Failed to set SSL cipher list \"%s\"", ssl_cipher_list);
           }
         }


### PR DESCRIPTION
According to manpage:

>     RETURN VALUES
>            SSL_CTX_set_cipher_list() and SSL_set_cipher_list() return
>            1 if any cipher could be selected and 0 on complete failure.

return code '1' is the one that is documented as expected.