### PR TITLE
Replace problematic string functions

### DIFF
--- a/include/u/libu.h
+++ b/include/u/libu.h
@@ -40,6 +40,9 @@
 #define strnicmp _strnicmp
 #define fileno _fileno
 #define cputs _cputs
+#if _MSC_VER < 1900
+  #define snprintf _snprintf
+#endif /* _MSC_VER < 1900 */
 #endif
 #ifndef TRUE
 #define TRUE    1

--- a/include/u/os.h
+++ b/include/u/os.h
@@ -41,7 +41,9 @@ pid_t getpid(void);
 #define strtoull(nptr, endptr, base) _strtoul_l(nptr, endptr, base, NULL)
 #define strtoll(nptr, endptr, base) _strtol_l(nptr, endptr, base, NULL)
 #define sleep(secs) Sleep( (secs) * 1000 )
-#define snprintf _snprintf              /*!< The snprintf is called _snprintf() in Win32 */
+#if _MSC_VER < 1900
+  #define snprintf _snprintf              /*!< The snprintf is called _snprintf() in Win32 */
+#endif /* _MSC_VER < 1900 */
 #define popen _popen
 #define getpid GetCurrentProcessId
 #define pclose _pclose

--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -502,6 +502,7 @@ static int iniparser_add_entry(
     } else {
         strncpy(longkey, sec, sizeof(longkey));
     }
+    longkey[sizeof(longkey)-1] = 0;
 
     /* Add (key,val) to dictionary */
     return dictionary_set(d, longkey, val);
@@ -925,7 +926,8 @@ dictionary * iniparser_new(char *ininame)
 
             if (sscanf(where, "[%[^]]", sec)==1) {
                 /* Valid section name */
-                strcpy(sec, strlwc(sec, lc_key));
+                strncpy(sec, strlwc(sec, lc_key), sizeof(sec));
+                sec[sizeof(sec)-1] = 0;
                 if (iniparser_add_entry(d, sec, NULL, NULL) != 0) {
                   dictionary_del(d);
                   fclose(ini);
@@ -936,7 +938,8 @@ dictionary * iniparser_new(char *ininame)
                    ||  sscanf (where, "%[^=] = %[^;#]",     key, val) == 2) {
                 char crop_key[ASCIILINESZ+1];
 
-                strcpy(key, strlwc(strcrop(key, crop_key), lc_key));
+                strncpy(key, strlwc(strcrop(key, crop_key), lc_key), sizeof(key));
+                key[sizeof(key)-1] = 0;
                 /*
                  * sscanf cannot handle "" or '' as empty value,
                  * this is done here
@@ -944,7 +947,8 @@ dictionary * iniparser_new(char *ininame)
                 if (!strcmp(val, "\"\"") || !strcmp(val, "''")) {
                     val[0] = (char)0;
                 } else {
-                    strcpy(val, strcrop(val, crop_key));
+                    strncpy(val, strcrop(val, crop_key), sizeof(val));
+                    val[sizeof(val)-1] = 0;
                 }
                 if (iniparser_add_entry(d, sec, key, val) != 0) {
                   dictionary_del(d);

--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -490,17 +490,17 @@ static void dictionary_dump(dictionary *d, FILE *f)
  */
 static int iniparser_add_entry(
     dictionary * d,
-    char * sec,
-    char * key,
+    const char * sec,
+    const char * key,
     char * val)
 {
     char longkey[2*ASCIILINESZ+1];
 
     /* Make a key as section:keyword */
     if (key!=NULL) {
-        sprintf(longkey, "%s:%s", sec, key);
+        snprintf(longkey, sizeof(longkey), "%s:%s", sec, key);
     } else {
-        strcpy(longkey, sec);
+        strncpy(longkey, sec, sizeof(longkey));
     }
 
     /* Add (key,val) to dictionary */
@@ -624,6 +624,7 @@ void iniparser_dump_ini(dictionary * d, FILE * f)
     int     nsec ;
     char *  secname ;
     int     seclen ;
+    int     ret ;
 
     if (d==NULL || f==NULL) return ;
 
@@ -641,8 +642,10 @@ void iniparser_dump_ini(dictionary * d, FILE * f)
         secname = iniparser_getsecname(d, i) ;
         seclen  = (int)strlen(secname);
         fprintf(f, "\n[%s]\n", secname);
-        sprintf(keym, "%s:", secname);
-        for (j=0 ; j<d->size ; j++) {
+        ret = snprintf(keym, sizeof(keym), "%s:", secname);
+        if (ret < 0 || ret >= sizeof(keym))
+            return;
+        for (j = 0 ; j < d->size ; j++) {
             if (d->key[j]==NULL)
                 continue ;
             if (!strncmp(d->key[j], keym, seclen+1)) {

--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -117,7 +117,8 @@ static char * strcrop(char * s, char * l)
 
     if ((s==NULL) || (l==NULL)) return NULL ;
     memset(l, 0, ASCIILINESZ+1);
-    strcpy(l, s);
+    strncpy(l, s, ASCIILINESZ + 1);
+    l[ASCIILINESZ] = '\0';
     last = l + strlen(l);
     while (last > l) {
         if (!isspace((int)*(last-1)))

--- a/src/lib/wsman-curl-client-transport.c
+++ b/src/lib/wsman-curl-client-transport.c
@@ -448,6 +448,7 @@ wsmc_handler( WsManClient *cl,
 	CURLcode r;
 	char *upwd = NULL;
 	char *usag = NULL;
+	size_t usag_len = 0;
 	struct curl_slist *headers=NULL;
 	char *buf = NULL;
 	int len;
@@ -495,7 +496,8 @@ wsmc_handler( WsManClient *cl,
 	snprintf(content_type, 64, "Content-Type: application/soap+xml;charset=%s", cl->content_encoding);
 	headers = curl_slist_append(headers, content_type);
 	tmp_str = wsman_transport_get_agent(cl);
-	usag = malloc(12 + strlen(tmp_str) + 1);
+	usag_len = strlen("User-Agent: ") + strlen(tmp_str) + 1;
+	usag = u_malloc(usag_len);
 	if (usag == NULL) {
 		r = CURLE_OUT_OF_MEMORY;
 		cl->fault_string = u_strdup("Could not malloc memory");
@@ -503,14 +505,14 @@ wsmc_handler( WsManClient *cl,
 		goto DONE;
 	}
 
-	sprintf(usag, "User-Agent: %s", tmp_str);
+	snprintf(usag, usag_len, "User-Agent: %s", tmp_str);
 	free(tmp_str);
 	headers = curl_slist_append(headers, usag);
 
 #if 0
 	soapaction = ws_xml_get_xpath_value(rqstDoc, "/s:Envelope/s:Header/wsa:Action");
 	if (soapaction) {
-		soapact_header = malloc(12 + strlen(soapaction) + 1);
+		soapact_header = u_malloc(12 + strlen(soapaction) + 1);
 		if (soapact_header) {
 			sprintf(soapact_header, "SOAPAction: %s", soapaction);
 			headers = curl_slist_append(headers, soapact_header);

--- a/src/lib/wsman-soap-envelope.c
+++ b/src/lib/wsman-soap-envelope.c
@@ -126,7 +126,12 @@ wsman_create_response_envelope(WsXmlDocH rqstDoc, const char *action)
 				size_t len = strlen(action) + sizeof(WSFW_RESPONSE_STR) + 2;
 				char *tmp = (char *) u_malloc(sizeof(char) * len);
 				if (tmp && action) {
-					sprintf(tmp, "%s%s", action, WSFW_RESPONSE_STR);
+					int ret;
+					ret = snprintf(tmp, len, "%s%s", action, WSFW_RESPONSE_STR);
+					if (ret < 0 ||  ret >= len) {
+						u_free(tmp);
+						return NULL;
+					}
 					ws_xml_add_child(dstHeader, XML_NS_ADDRESSING,
 							 WSA_ACTION, tmp);
 					u_free(tmp);


### PR DESCRIPTION
The sprintf, strcpy and such are banned from usage by security practices.
Replace them with more secure equivalents. 