### PR TITLE
c++ fixes

### DIFF
--- a/src/cpp/WsmanEPR.cpp
+++ b/src/cpp/WsmanEPR.cpp
@@ -29,6 +29,12 @@ WsmanEPR::WsmanEPR(WsmanEPR &epr)
 {
 }
 
+WsmanEPR& WsmanEPR::operator=(const WsmanEPR &other)
+{
+	epr = epr_copy(other.getepr());
+	return *this;
+}
+
 WsmanEPR::~WsmanEPR()
 {
 	if (epr) {

--- a/src/cpp/WsmanEPR.h
+++ b/src/cpp/WsmanEPR.h
@@ -16,6 +16,7 @@ public:
 	WsmanEPR(const string &eprstring);
 	WsmanEPR(const string &uri, const string &address);
 	WsmanEPR(WsmanEPR &epr);
+	WsmanEPR& operator=(const WsmanEPR &other);
 	~WsmanEPR();
 
 	int addTextSelector(const string &name, const string &value);

--- a/src/cpp/WsmanFilter.cpp
+++ b/src/cpp/WsmanFilter.cpp
@@ -51,7 +51,7 @@ WsmanFilter::WsmanFilter(
 	char **props = NULL;
 
 	if (!resultProp.empty()) {
-		props = static_cast<char**>(malloc(sizeof(char *) * resultProp.size()));
+		props = new char* [resultProp.size()];
 		vector<string>::const_iterator itr;
 		for (itr = resultProp.begin(); itr != resultProp.end(); itr++, i++) {
 			props[i] = const_cast<char*>(itr->c_str());
@@ -67,7 +67,7 @@ WsmanFilter::WsmanFilter(
 		(resultRole.empty() ? NULL : resultRole.c_str()),
 		props, i);
 
-	free(props);
+	 delete [] props;
 }
 
 WsmanFilter::~WsmanFilter()

--- a/src/cpp/WsmanFilter.cpp
+++ b/src/cpp/WsmanFilter.cpp
@@ -32,6 +32,12 @@ WsmanFilter::WsmanFilter(const NameValuePairs *s)
 	addSelectors(s);
 }
 
+WsmanFilter& WsmanFilter::operator=(const WsmanFilter &other)
+{
+	filter = filter_copy(other.getFilter());
+	return *this;
+}
+
 WsmanFilter::WsmanFilter(
 	const WsmanEPR &epr,
 	enum WsmanAssocType assocType,

--- a/src/cpp/WsmanFilter.h
+++ b/src/cpp/WsmanFilter.h
@@ -25,6 +25,7 @@ namespace WsmanClientNamespace {
 
 		public:
 			WsmanFilter(const WsmanFilter &filter);
+			WsmanFilter& operator=(const WsmanFilter &other);
 			WsmanFilter(const string &dialect, const string &query);
 			WsmanFilter(const NameValuePairs *s = NULL);
                         WsmanFilter(


### PR DESCRIPTION
Fixes for C++ code:
Add explicit assignment operator where required and use new instead of malloc.