### PR TITLE
wsman-client: fix action options accessors

### DIFF
--- a/bindings/wsman-client_opt.i
+++ b/bindings/wsman-client_opt.i
@@ -65,7 +65,7 @@ typedef struct {} client_opt_t;
   }
 
 #if defined(SWIGRUBY)
-  %rename( "flags=" ) set_flags(int flags);
+  %rename( "flags=" ) set_flags(unsigned long flags);
 #endif
   /*
    * set option flag(s)
@@ -76,7 +76,7 @@ typedef struct {} client_opt_t;
    *   options.flags = Openwsman::FLAG_ENUMERATION_OPTIMIZATION
    *
    */
-  void set_flags(int flags) {
+  void set_flags(unsigned long flags) {
     wsmc_set_action_option($self, flags);
   }
 
@@ -92,7 +92,7 @@ typedef struct {} client_opt_t;
    *   optins.flags -> Integer
    *
    */
-  unsigned int get_flags() {
+  unsigned long get_flags() {
     return wsmc_get_action_option($self);
   }
 
@@ -105,7 +105,7 @@ typedef struct {} client_opt_t;
    *   options.clear_flags Openwsman::FLAG_ENUMERATION_OPTIMIZATION
    *
    */
-  void clear_flags(int flags) {
+  void clear_flags(unsigned long flags) {
     wsmc_clear_action_option($self, flags);
   }
 

--- a/include/wsman-client-api.h
+++ b/include/wsman-client-api.h
@@ -744,12 +744,12 @@ typedef enum {
 					     client_opt_t * options);
 
 	void wsmc_set_action_option(client_opt_t * options,
-				     unsigned int);
+				     unsigned long);
 
-	unsigned int wsmc_get_action_option(client_opt_t * options);
+	unsigned long wsmc_get_action_option(client_opt_t * options);
 
 	void wsmc_clear_action_option(client_opt_t * options,
-				     unsigned int);
+				     unsigned long);
 
 	void wsmc_set_options_from_uri(const char *resource_uri,
 					client_opt_t * options);

--- a/src/lib/wsman-client.c
+++ b/src/lib/wsman-client.c
@@ -373,14 +373,14 @@ wsmc_options_destroy(client_opt_t * op)
 }
 
 void
-wsmc_set_action_option(client_opt_t * options, unsigned int flag)
+wsmc_set_action_option(client_opt_t * options, unsigned long flag)
 {
 	options->flags |= flag;
 	return;
 }
 
 
-unsigned int
+unsigned long
 wsmc_get_action_option(client_opt_t * options)
 {
 	return options->flags;
@@ -388,7 +388,7 @@ wsmc_get_action_option(client_opt_t * options)
 
 
 void
-wsmc_clear_action_option(client_opt_t * options, unsigned int flag)
+wsmc_clear_action_option(client_opt_t * options, unsigned long flag)
 {
 	options->flags &= ~flag;
 	return;


### PR DESCRIPTION
flags variable is unsigned long, but all accessors are unsigned int.
Update accessors to unsigned long to eliminate type size
incompatibility problems.

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>