### PR TITLE
Add option to compile with msvc static runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,6 +502,11 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/openwsman.pc
               ${CMAKE_CURRENT_BINARY_DIR}/openwsman++.pc
 	      ${CMAKE_CURRENT_BINARY_DIR}/openwsman-server.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
 
+OPTION(MSVC_STATIC_RUNTIME "Use multi-threaded statically-linked runtime library" NO)
+IF(MSVC_STATIC_RUNTIME)
+ add_compile_options(/MT$<$<CONFIG:Debug>:d>)
+ENDIF(MSVC_STATIC_RUNTIME)
+
 add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(doc)


### PR DESCRIPTION
MSVC by default links against dynamic runtime library,
add option to link against static runtime.

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>