### PR TITLE
openwsman: fix trivial spelling errors

### DIFF
--- a/bindings/python/pywsman/README.rst
+++ b/bindings/python/pywsman/README.rst
@@ -35,7 +35,7 @@ Building from within the openwsman source directory
 
 Running ``setup.py install``, or similar, from within the openwsman source directory, will cause the setup script to look for its include files in the source directory, as opposed to an installation path on the system. 
 
-NOTE: Shared libaries will still be sourced from the standard system location(s).
+NOTE: Shared libraries will still be sourced from the standard system location(s).
 
 About the bindings
 ==================

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -106,7 +106,7 @@ ADD_CUSTOM_COMMAND (
 
 #
 # Prep GEM files
-# gemspec needs _relative_ pathes
+# gemspec needs _relative_ paths
 # so create ext and lib here and copy files
 #
 ADD_CUSTOM_COMMAND (

--- a/bindings/ruby/parse_swig.rb
+++ b/bindings/ruby/parse_swig.rb
@@ -358,7 +358,7 @@ module RDoc
    end
 
     ##
-    # Adds constant comments.  By providing some_value: at the start ofthe
+    # Adds constant comments.  By providing some_value: at the start of the
     # comment you can override the C value of the comment to give a friendly
     # definition.
     #

--- a/bindings/ruby/tests/each_child.rb
+++ b/bindings/ruby/tests/each_child.rb
@@ -52,9 +52,9 @@ class WsmanTest < Test::Unit::TestCase
 
     node.each do |child|
       text = child.text
-      acount = child.attr_count
-      puts "Child [#{acount}] #{child.name}: #{text}"
-      if acount > 0
+      account = child.attr_count
+      puts "Child [#{account}] #{child.name}: #{text}"
+      if account > 0
 	child.each_attr{ |attr| puts "\tAttr #{attr.ns}:#{attr.name}=#{attr.value}" }
       end
       #	return false if text.nil?

--- a/doc/plugin-framwork.txt
+++ b/doc/plugin-framwork.txt
@@ -25,14 +25,14 @@ and send this package to client.
                        |         WS-MAN         |
                        --------------------------
 
-1. Importand Data Structure
+1. Important Data Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 struct __WsDispatchInterfaceInfo
 {
 	unsigned long flags;                // reserved
 	char *notes;                        // plugin information -- note
 	char *vendor;                       // plugin information -- vendor
-	char *displayName;                  // plugin information -- titile
+	char *displayName;                  // plugin information -- title
 	char *compliance;                   // compliant protocol
 	char *actionUriBase;                // base part of the action URI string
 	char *wsmanSystemUri;               // WS-MAN system URI, it may be NULL
@@ -52,7 +52,7 @@ struct __WsSelector
                                             // mof class keybind.
 	char *value;                        // selector value
 	char *type;                         // selector type,
-	char *description;                  // decription of 
+	char *description;                  // description of
 };
 typedef struct __WsSelector WsSelector;
 
@@ -87,10 +87,10 @@ struct __WsDispatchEndPointInfo
 	struct __XmlSerializerInfo* serializationInfo;  
                                                // pointer to a table, used to 
                                                // serialize this endpoint
-	WsProcType serviceEndPoint;            // hook fuction for this endpoint
+	WsProcType serviceEndPoint;            // hook function for this endpoint
 	void* data;                            // pointer to the base resource 
                                                // URI, used as a namespace
-	struct __WsSelector* selectors;        // pointer to a seclector table,
+	struct __WsSelector* selectors;        // pointer to a selector table,
                                                // It may be NULL.
 };
 typedef struct __WsDispatchEndPointInfo WsDispatchEndPointInfo;
@@ -110,7 +110,7 @@ struct __XmlSerializerInfo
                                           // elementd; > 1 for fixed size             
                                           // array; 0 for dynamic array.              
 	unsigned short funcMaxCount;                                                        
-	XmlSerializationProc proc;        // hook fuction for this property,          
+	XmlSerializationProc proc;        // hook function for this property,          
                                           // used to serialize this property.         
                                           // it can be one of do_serialize_xxx        
 	XML_TYPE_PTR extData;             // if type of this property is a            
@@ -120,7 +120,7 @@ struct __XmlSerializerInfo
 };
 typedef struct __XmlSerializerInfo XmlSerializerInfo;
 
-This structure deccribes all Serialization type information for resource
+This structure describes all Serialization type information for resource
 ================================================================================
 
 2. useful MACRO
@@ -386,7 +386,7 @@ void get_endpoints(GModule *self, void **data);
 
 This is the only way that the plugin framework collects all endpoints
 information about this plugin, so in this interface body, the plugin should
-initialize the WsDispatchEndPointInfo structre pointed by data.
+initialize the WsDispatchEndPointInfo structure pointed by data.
 
 for example:
 void get_endpoints(GModule *self, void **data) 

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -259,7 +259,7 @@ static void example2(void)
 					       CLASSNAME, NULL, NULL,
 					       0, 0);
 	if (cs == NULL) {
-		printf("Errror ws_deserialize\n");
+		printf("Error ws_deserialize\n");
 		return;
 	}
 
@@ -332,7 +332,7 @@ static void example3(void)
 					       CLASSNAME, NULL, NULL,
 					       0, 0);
 	if (cs == NULL) {
-		printf("Errror ws_serialize\n");
+		printf("Error ws_serialize\n");
 		return;
 	}
 
@@ -605,7 +605,7 @@ static void example6(void)
 					 CLASSNAME,
 					 XML_NS_ADDRESSING, NULL, 0, 0);
 	if (news == NULL) {
-		printf("Errror ws_deserialize\n");
+		printf("Error ws_deserialize\n");
 		return;
 	}
 
@@ -758,7 +758,7 @@ static void example7(void)
 					"EndpointReference",
 					XML_NS_ADDRESSING, NULL, 0, 0);
 	if (newEPR == NULL) {
-		printf("Errror ws_deserialize\n");
+		printf("Error ws_deserialize\n");
 		return;
 	}
 
@@ -888,7 +888,7 @@ static void example10()
 	WsXmlDocH doc = ws_xml_read_memory(xmlstring, strlen(xmlstring), "UTF-8", 0);
 	WsXmlNodeH node = ws_xml_get_doc_root(doc);
 	 printf
-            ("\n\n   ********   example10. xsi:nil attibute test  ********\n");
+            ("\n\n   ********   example10. xsi:nil attribute test  ********\n");
 	WsSerializerContextH cntx = ws_serializer_init();
 	if (cntx == NULL) {
                 printf("Error ws_create_runtime\n");
@@ -965,7 +965,7 @@ static void example11()
 					       CLASSNAME, NULL, NULL,
 					       0, 0);
 	if (cs == NULL) {
-		printf("Errror ws_deserialize\n");
+		printf("Error ws_deserialize\n");
 		return;
 	}
 

--- a/include/u/hash.h
+++ b/include/u/hash.h
@@ -98,7 +98,7 @@ typedef int (*hash_comp_t)(const void *, const void *);
  * particular, the most significant bits of hash_val_t are most significant to
  * the hash module. Only as the hash table expands are less significant bits
  * examined. Thus a function that has good distribution in its upper bits but
- * not lower is preferrable to one that has poor distribution in the upper bits
+ * not lower is preferable to one that has poor distribution in the upper bits
  * but not the lower ones.
  */
 

--- a/include/wsman-client-api.h
+++ b/include/wsman-client-api.h
@@ -222,7 +222,7 @@ typedef enum {
  	* @param path HTTP path, for example /wsman
  	* @param scheme scheme, HTTP or HTTPS
  	* @param username User name
- 	* @param password Passwrod
+ 	* @param password Password
  	* @return client handle
  	*/
 	WsManClient *wsmc_create(const char *hostname,

--- a/include/wsman-epr.h
+++ b/include/wsman-epr.h
@@ -105,20 +105,20 @@ epr_t *epr_create(const char *uri, hash_t * selectors,
  epr_t *epr_from_string(const char* str);
 
 /**
- * Add a new text selector to an exsiting epr
+ * Add a new text selector to an existing epr
  * @param epr Point of epr_t
  * @param name Name of selector
- * @param selector Point of seletor_entry
- * @return 0 for sucess, others for failure
+ * @param selector Point of selector_entry
+ * @return 0 for success, others for failure
  */
 int epr_add_selector_text(epr_t *epr, const char *name, const char *text);
 
 /**
- * Add a new epr selector to an exsiting epr
+ * Add a new epr selector to an existing epr
  * @param epr Point of epr_t
  * @param name Name of selector
- * @param selector Point of seletor_entry
- * @return 0 for sucess, others for failure
+ * @param selector Point of selector_entry
+ * @return 0 for success, others for failure
  */
 int epr_add_selector_epr(epr_t *epr, const char *name, epr_t *added_epr);
 
@@ -126,7 +126,7 @@ int epr_add_selector_epr(epr_t *epr, const char *name, epr_t *added_epr);
  * Delete an selector from an epr by name
  * @param epr Point of epr_t
  * @param name Name of selector name
- * @return 0 for sucess, others for failure
+ * @return 0 for success, others for failure
  */
 int epr_delete_selector(epr_t *epr, const char *name);
 

--- a/include/wsman-filter.h
+++ b/include/wsman-filter.h
@@ -78,13 +78,13 @@ int filter_set_assoc(filter_t *filter, epr_t *epr, const int assocType, const ch
 /**
  * Create a new filter_t with a simple query string
  * @param dialect Filter dialect string
- * @param query Query sting
- * @ return created filter_t strucrture point
+ * @param query Query string
+ * @ return created filter_t structure point
  */
 filter_t * filter_create_simple(const char *dialect, const char *query);
 
 /**
- * Create a new filter_t with assciation query
+ * Create a new filter_t with association query
  * @param epr EPR structure, Identifies the source object for the association query and is required
  * @param assocType Association query type: 0 for associated instances, 1 for association instances
  * @param assocClass Represents the name of a CIM association class.  Optional
@@ -93,7 +93,7 @@ filter_t * filter_create_simple(const char *dialect, const char *query);
  * @param resultRole Represents the name of a key reference property of a CIM association class.  Optional
  * @param resultProp Represents the name of one or more properties of a CIM class. Optional
  * @param propNum Number of resultProp
- * @return created filter_t strucrture point
+ * @return created filter_t structure point
  */
 filter_t * filter_create_assoc(epr_t *epr, const int assocType, const char *assocClass,
 	const char *resultClass, const char *role, const char *resultRole, char **resultProp,

--- a/include/wsman-subscription-repository.h
+++ b/include/wsman-subscription-repository.h
@@ -54,10 +54,10 @@ struct __SubsRepositoryEntry {
 typedef struct __SubsRepositoryEntry *SubsRepositoryEntryH;
 
 struct __SubsRepositoryOpSet{
-        SubscriptionOpInit init_subscription; //entry of initializing subscripton repository
+        SubscriptionOpInit init_subscription; //entry of initializing subscription repository
         SubscriptionOpFinalize finalize_subscription; //entry of finalizing subscription repository
         SubscriptionOpLoad load_subscription; //entry of loading all of subscriptions
-        SubscriptionOpGet get_subscription; //entry of geting a subscription from the repository
+        SubscriptionOpGet get_subscription; //entry of getting a subscription from the repository
         SubscriptionOpSearch search_subscription; //entry of searching a subscription from the repository
         SubscriptionOpSave save_subscritption; //entry of saving a subscription in the repository
         SubscriptionOpUpdate update_subscription; //entry of updating a subscription

--- a/include/wsman-xml.h
+++ b/include/wsman-xml.h
@@ -114,7 +114,7 @@ void ws_xml_set_node_lang(WsXmlNodeH node, const char *lang);
 
 void ws_xml_unlink_node(WsXmlNodeH node);
 
-//to check if the size of envelop exceeds a maxium size
+// to check if the size of envelop exceeds a maximum size
 int check_envelope_size(WsXmlDocH doc, unsigned int size, const char *charset);
 
 /** @} */

--- a/src/lib/u/buf.c
+++ b/src/lib/u/buf.c
@@ -1,5 +1,5 @@
-/* 
- * Copyright (c) 2005, 2006 by KoanLogic s.r.l. - All rights reserved.  
+/*
+ * Copyright (c) 2005, 2006 by KoanLogic s.r.l. - All rights reserved.
  */
 
 static const char rcsid[] =
@@ -30,7 +30,7 @@ struct u_buf_s
  */
 
 /**
- * \brief  Enlarge the underlaying memory block of the given buffer
+ * \brief  Enlarge the underlying memory block of the given buffer
  *
  * Enlarge the buffer data block to (at least) \a size bytes.
  *
@@ -47,7 +47,7 @@ int u_buf_reserve(u_buf_t *ubuf, size_t size)
 
     if(size <= ubuf->size)
         return 0; /* nothing to do */
-   
+
     /* size plus 1 char to store a '\0' */
     nbuf = u_realloc(ubuf->data, size+1);
     dbg_err_if(nbuf == NULL);
@@ -145,14 +145,14 @@ err:
     if(fp)
         fclose(fp);
     return ~0;
-}
+
 
 /**
- * \brief  Release buffer's underlaying memory block without freeing it
+ * \brief  Release buffer's underlying memory block without freeing it
  *
- * Release the underlaying memory block of the given buffer without 
+ * Release the underlying memory block of the given buffer without
  * calling free() on it. The caller must free the buffer later on (probably
- * after using it somwhow). 
+ * after using it somehow).
  *
  * Use u_buf_ptr() to get the pointer of the memory block, u_buf_size() to
  * get its size and u_buf_len() to get its length.
@@ -269,7 +269,7 @@ char *u_buf_steal(u_buf_t *ubuf)
 
 
 /**
- * \brief  Return a pointer to the buffer internal momory block
+ * \brief  Return a pointer to the buffer internal memory block
  *
  * Return a void* pointer to the memory block allocated by the buffer object.
  *

--- a/src/lib/u/hash.c
+++ b/src/lib/u/hash.c
@@ -153,7 +153,7 @@ static void clear_table(hash_t *hash)
  * 8.  The low chain replaces the current chain.  The high chain goes
  *     into the corresponding sister chain in the upper half of the table.
  * 9.  We have finished dealing with the chains and nodes. We now update
- *     the various bookeeping fields of the hash structure.
+ *     the various bookkeeping fields of the hash structure.
  */
 
 static void grow_table(hash_t *hash)

--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -200,7 +200,7 @@ static unsigned dictionary_hash(char * key)
 /**
   @brief    Create a new dictionary object.
   @param    size    Optional initial size of the dictionary.
-  @return   1 newly allocated dictionary objet.
+  @return   1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the

--- a/src/lib/u/list.c
+++ b/src/lib/u/list.c
@@ -395,7 +395,7 @@ void ow_list_sort(list_t *list, int compare(const void *, const void *))
 	ow_list_sort(list, compare);
 	/* sort 'right' half */
 	ow_list_sort(&extra, compare);
-	/* merge sorted halfs */
+	/* merge sorted halves */
 	ow_list_merge(list, &extra, compare);
     } 
     assert (list_is_sorted(list, compare));

--- a/src/lib/u/misc.c
+++ b/src/lib/u/misc.c
@@ -188,7 +188,7 @@ void* u_memdup(const void *src, size_t size)
  * Tokenize the \p delim separated string \p wlist and place its
  * pieces (at most \p tokv_sz - 1) into \p tokv.
  *
- * \param wlist     list of strings possibily separated by chars in \p delim
+ * \param wlist     list of strings possibly separated by chars in \p delim
  * \param delim     set of token separators
  * \param tokv      pre-allocated string array
  * \param tokv_sz   number of cells in \p tokv array

--- a/src/lib/wsman-client.c
+++ b/src/lib/wsman-client.c
@@ -92,7 +92,7 @@ wsman_make_action(const char *uri, const char *op_name)
 		if (ptr) {
 			int ret = snprintf(ptr, len, "%s/%s", uri, op_name);
 			if (ret < 0 || ret >= len) {
-				error("Error: formating action");
+				error("Error: formatting action");
 				u_free(ptr);
 				return NULL;
 			}
@@ -170,7 +170,7 @@ wsmc_build_envelope(WsSerializerContextH serctx,
 				(unsigned int) options->timeout / 1000,
 				(unsigned int) options->timeout % 1000);
 		if (ret < 0 || ret >= sizeof(buf)) {
-			error("Error: formating time");
+			error("Error: formatting time");
 			return NULL;
 		}
 		ws_serialize_str(serctx, header, buf,
@@ -1942,7 +1942,7 @@ wsmc_free_enum_context(char *enumcontext)
 
 
 /**
- * Buid Inbound Envelope from Response
+ * Build Inbound Envelope from Response
  * @param cl Client Handler
  * @return XML document with Envelope
  */
@@ -2187,7 +2187,7 @@ wsmc_create(const char *hostname,
                                              (*wsc->data.path == '/') ? "" : "/",
                                              wsc->data.path);
 	debug("Endpoint: %s", wsc->data.endpoint);
-	wsc->authentication.verify_host = 1; //verify CN in server certicates by default
+	wsc->authentication.verify_host = 1; //verify CN in server certificates by default
 	wsc->authentication.verify_peer = 1; //validate server certificates by default
 #ifndef _WIN32
 	wsc->authentication.crl_check = 0;   // No CRL check by default

--- a/src/lib/wsman-curl-client-transport.c
+++ b/src/lib/wsman-curl-client-transport.c
@@ -240,7 +240,7 @@ write_handler( void *ptr, size_t size, size_t nmemb, void *data)
 
 	len = size * nmemb;
 	u_buf_append(buf, ptr, len);
-	debug("write_handler: recieved %d bytes, all = %d\n", len, u_buf_len(buf));
+	debug("write_handler: received %d bytes, all = %d\n", len, u_buf_len(buf));
 	return len;
 }
 
@@ -660,9 +660,9 @@ wsmc_handler( WsManClient *cl,
                 size_t inbuf_len = outbuf_len;
                 char *inbuf = u_buf_ptr(response);
                 char *outbuf = mbbuf;
-                size_t coverted = iconv(cd, &inbuf, &inbuf_len, &outbuf, &outbuf_len);
+                size_t converted = iconv(cd, &inbuf, &inbuf_len, &outbuf, &outbuf_len);
 		  iconv_close(cd);
-                if( coverted == -1) {
+                if( converted == -1) {
 			cl->last_error = WS_LASTERR_BAD_CONTENT_ENCODING;
 			goto DONE2;
                 }

--- a/src/lib/wsman-dispatcher.c
+++ b/src/lib/wsman-dispatcher.c
@@ -143,7 +143,7 @@ generate_notunderstood_fault(op_t * op,
 					      (notUnderstoodHeader));
 		}
 	} else {
-		error("cant generate fault");
+		error("can't generate fault");
 	}
 	return;
 }

--- a/src/lib/wsman-soap-envelope.c
+++ b/src/lib/wsman-soap-envelope.c
@@ -173,7 +173,7 @@ int wsman_check_identify(WsmanMessage * msg)
 }
 
 /**
- * Buid Inbound Envelope
+ * Build Inbound Envelope
  * @param buf Message buffer
  * @return XML document with Envelope
  */
@@ -237,7 +237,7 @@ wsman_get_soap_header_element(WsXmlDocH doc, const char *nsUri, const char *name
  * @param faultNsUri Fault Namespace URI
  * @param code Fault code
  * @param subCode Fault Subcode
- * @param reason Fault Reson
+ * @param reason Fault Reason
  * @param detail Fault Details
  * @return Fault XML document
  */

--- a/src/lib/wsman-soap.c
+++ b/src/lib/wsman-soap.c
@@ -1014,7 +1014,7 @@ extern int wsmand_options_get_max_connections_per_thread(void);
 
 /**
  * Enumeration Stub for processing enumeration requests
- * @param op SOAP pperation handler
+ * @param op SOAP operation handler
  * @param appData Application data
  * @return status
  */
@@ -1636,7 +1636,7 @@ create_subs_info(SoapOpH op,
 	}
 	subsInfo->uri = u_strdup(wsman_get_resource_uri(epcntx, indoc));
 	if(!subNode) {
-		message("No subsribe body");
+		message("No subscribe body");
 		fault_code = WSE_INVALID_MESSAGE;
 		goto DONE;
 	}
@@ -1795,7 +1795,7 @@ create_subs_info(SoapOpH op,
 	temp = ws_xml_get_soap_header(indoc);
 	temp = ws_xml_get_child(temp, 0, XML_NS_OPENWSMAN, "FormerUID");
 	ntext = ws_xml_get_node_text(temp);
-	if(temp && ntext) { //it is a request from the saved reqeust. So we recover the former UUID
+	if(temp && ntext) { //it is a request from the saved request. So we recover the former UUID
 		strncpy(subsInfo->subsId, ntext, EUIDLEN);
 		debug("Recover to uuid:%s",subsInfo->subsId);
 	}
@@ -1816,7 +1816,7 @@ DONE:
 
 /**
  * Subscribe Stub for processing subscription requests
- * @param op SOAP pperation handler
+ * @param op SOAP operation handler
  * @param appData Application data
  * @return status
  */
@@ -1933,7 +1933,7 @@ DONE:
 
 /**
  * Unsubscribe Stub for processing unsubscription requests
- * @param op SOAP pperation handler
+ * @param op SOAP operation handler
  * @param appData Application data
  * @return status
  */
@@ -2016,7 +2016,7 @@ DONE:
 
 /**
  * Renew Stub for processing renew requests
- * @param op SOAP pperation handler
+ * @param op SOAP operation handler
  * @param appData Application data
  * @return status
  */

--- a/src/lib/wsman-xml-serialize.c
+++ b/src/lib/wsman-xml-serialize.c
@@ -209,7 +209,7 @@ handle_attrs(struct __XmlSerializationData *data,
 	}
 	debug("initial DATABUF = %p", DATA_BUF(data));
 	DATA_BUF(data) = DATA_BUF(data) + pad;
-	debug("alligned databuf = %p; pad = 0x%x", DATA_BUF(data), pad);
+	debug("aligned databuf = %p; pad = 0x%x", DATA_BUF(data), pad);
 
 	if (data->mode == XML_SMODE_FREE_MEM) {
 		// XXXXX   free memory
@@ -1307,7 +1307,7 @@ int do_serialize_dyn_size_array(XmlSerializationData * data)
 	}
 
 	if (dyn->count == 0) {
-		// no dynamic data. nothing to do
+		// no dynamic data, nothing to do
 		goto DONE;
 	}
 
@@ -1429,7 +1429,7 @@ int do_serialize_struct(XmlSerializationData * data)
 			child = xml_serializer_add_child(data, NULL);
 			data->xmlNode = child;
 			if (data->xmlNode == NULL) {
-				error("cant add child");
+				error("can't add child");
 				retVal = WS_ERR_INSUFFICIENT_RESOURCES;
 				goto DONE;
 			}
@@ -1748,7 +1748,7 @@ int ws_deserialize_duration(const char *t, time_t * value)
 		t++;
 	}
 	if (*t != 'P') {
-		debug("Wrong begining of duration");
+		debug("Wrong beginning of duration");
 		goto DONE;
 	}
 	while (*++t) {
@@ -1836,7 +1836,7 @@ int ws_deserialize_duration(const char *t, time_t * value)
 	}
 
 	// We don't know exact date and time of the sender.
-	// For simplicity comsider 1 month = 30days;
+	// For simplicity consider 1 month = 30days;
 
 	vs = secs + 60 * mins + 60 * 60 * hours + 60 * 60 * 24 * days +
 	    60 * 60 * 24 * 30 * months + 60 * 60 * 24 * 30 * 12 * years;

--- a/src/lib/wsman-xml.c
+++ b/src/lib/wsman-xml.c
@@ -194,7 +194,7 @@ static char *make_qname(WsXmlNodeH node, const char *uri, const char *name)
  * @param value Child Value
  * @return Child XML node
  * @note
- * if namespaces has been changed after this function is called, itis caller's
+ * if namespaces has been changed after this function is called, it is caller's
  * responsibility to update QName fields accordingly
  */
 WsXmlAttrH ws_xml_add_qname_attr(WsXmlNodeH node,
@@ -790,7 +790,7 @@ ws_xml_get_child(WsXmlNodeH parent,
  * @param nsUri Namespace URI
  * @param name node name
  * @return Returns 1 if node is QName
- * @brief Shortcats for QName manipulation name can be NULL, in this case just check namespace
+ * @brief Shortcuts for QName manipulation name can be NULL, in this case just check namespace
  */
 int ws_xml_is_node_qname(WsXmlNodeH node, const char *nsUri,
 			 const char *name)

--- a/src/plugins/cim/sfcc-interface.c
+++ b/src/plugins/cim/sfcc-interface.c
@@ -1822,7 +1822,7 @@ cim_invoke_method(CimClientInfo * client,
 		}
 
 	        if (strstr(client->resource_uri, XML_NS_CIM_INTRINSIC) != NULL) {
-			debug("Instrinsic op ?: %s", client->method);
+			debug("Intrinsic op ?: %s", client->method);
 
 			if (!strcmp(client->method, CIM_ACTION_ENUMERATE_CLASS_NAMES))
 				invoke_enumerate_class_names(client, body, &rc);
@@ -2544,7 +2544,7 @@ cim_create_indication_subscription(CimClientInfo * client, WsSubscribeInfo *subs
 			rc.rc, (rc.msg) ? CMGetCharPtr(rc.msg) : NULL);
 	if (rc.rc == CMPI_RC_ERR_FAILED) {
 		status->fault_code = WSA_ACTION_NOT_SUPPORTED;
-	} else if (rc.rc != 11){ // an object already exists. We take this erros as success
+	} else if (rc.rc != 11){ // an object already exists. We take this error as success
 		cim_to_wsman_status(rc, status);
 	}
 	if (rc.msg)

--- a/src/server/gss.c
+++ b/src/server/gss.c
@@ -181,7 +181,7 @@ int do_gss(struct conn *c)
 
     // pp = start, p = end. Now decode
 
-    char decbuf[p - pp]; // this is too long but we dont care
+    char decbuf[p - pp]; // this is too long but we don't care
     int l = ws_base64_decode(pp, p - pp, decbuf, 4095);
 
     int ret = connectContext(decbuf, l, gsscreds, &c->gss_ctx, &client_name, &reply, &retflags);
@@ -192,7 +192,7 @@ int do_gss(struct conn *c)
     }
 
     // encode the reply
-    char repbuf[reply.length * 2]; // again, too large but we dont care
+    char repbuf[reply.length * 2]; // again, too large but we don't care
 
     ws_base64_encode(reply.value, reply.length, repbuf);
 
@@ -267,7 +267,7 @@ int gss_encrypt(struct shttpd_arg *arg, char *input, int inlen, char **output, i
         displayError("wrapping message", maj_stat, min_stat);
         return -1;
     }
-    // thsi is the encryption space overhead
+    // this is the encryption space overhead
     *p++ = out_buf.length - in_buf.length - 1; // not quite sure why I need -1 but I do. Its all to do with the gss pad byte
     *p++ = 0;
     *p++ = 0;

--- a/src/server/shttpd/compat_rtems.c
+++ b/src/server/shttpd/compat_rtems.c
@@ -132,7 +132,7 @@ set_close_on_exec(int fd)
 {
         // RTEMS Does not have a functional "execve"
         // so technically this call does not do anything,
-        // but it doesnt hurt either.
+        // but it doesn't hurt either.
         (void) fcntl(fd, F_SETFD, FD_CLOEXEC);
 }
 

--- a/src/server/shttpd/compat_win32.c
+++ b/src/server/shttpd/compat_win32.c
@@ -442,7 +442,7 @@ _shttpd_spawn_process(struct conn *c, const char *prog, char *envblk,
 			(void) fgets(line, sizeof(line), fp);
 			if (memcmp(line, "#!", 2) != 0)
 				line[2] = '\0';
-			/* Trim whitespaces from interpreter name */
+			/* Trim white spaces from interpreter name */
 			for (p = &line[strlen(line) - 1]; p > line &&
 			    isspace(*p); p--)
 				*p = '\0';
@@ -464,7 +464,7 @@ _shttpd_spawn_process(struct conn *c, const char *prog, char *envblk,
 
 	/*
 	 * Spawn reader & writer threads before we create CGI process.
-	 * Otherwise CGI process may die too quickly, loosing the data
+	 * Otherwise CGI process may die too quickly, losing the data
 	 */
 	spawn_stdio_thread(sock, b[0], stdinput, 0);
 	spawn_stdio_thread(sock, a[1], stdoutput, c->rem.content_len);

--- a/src/server/shttpd/io_cgi.c
+++ b/src/server/shttpd/io_cgi.c
@@ -47,7 +47,7 @@ read_cgi(struct stream *stream, void *buf, size_t len)
 	 * may alter the status code. Buffer in headers, parse
 	 * them, send correct status code and then forward all data
 	 * from CGI script back to the remote end.
-	 * Reply line was alredy appended to the IO buffer in
+	 * Reply line was already appended to the IO buffer in
 	 * decide_what_to_do(), with blank status code.
 	 */
 

--- a/src/server/shttpd/shttpd.c
+++ b/src/server/shttpd/shttpd.c
@@ -444,7 +444,7 @@ _shttpd_get_mime_type(struct shttpd_ctx *ctx,
 	const char	*eq, *p = ctx->options[OPT_MIME_TYPES];
 	int		i, n, ext_len;
 
-	/* Firt, loop through the custom mime types if any */
+	/* First, loop through the custom mime types if any */
 	FOR_EACH_WORD_IN_LIST(p, n) {
 		if ((eq = memchr(p, '=', n)) == NULL || eq >= p + n || eq == p)
 			continue;
@@ -769,7 +769,7 @@ add_socket(struct worker *worker, int sock, int is_ssl)
 #if !defined(NO_SSL)
 	SSL		*ssl = NULL;
 #else
-	is_ssl = is_ssl;	/* supress warnings */
+	is_ssl = is_ssl;	/* suppress warnings */
 #endif /* NO_SSL */
 
 	sa.len = sizeof(sa.u.sin);

--- a/src/server/shttpd/shttpd.h
+++ b/src/server/shttpd/shttpd.h
@@ -65,7 +65,7 @@ typedef void (*shttpd_callback_t)(struct shttpd_arg *);
 
 /*
  * shttpd_init		Initialize shttpd context
- * shttpd_fini		Dealocate the context, close all connections
+ * shttpd_fini		Deallocate the context, close all connections
  * shttpd_set_option	Set new value for option
  * shttpd_register_uri	Setup the callback function for specified URL
  * shttpd_poll		Do connections processing

--- a/src/server/wsmand-listener.c
+++ b/src/server/wsmand-listener.c
@@ -197,7 +197,7 @@ void server_callback(struct shttpd_arg *arg)
 	char *payload = 0; // used for gss encrypt
 
 	if (ct && !memcmp(ct, "multipart/encrypted", 19)) {
-	        // we have a encrypted payload. decrypt it 
+	        // we have a encrypted payload, decrypt it 
         	payload = gss_decrypt(arg, u_buf_ptr(state->request), u_buf_len(state->request));
 	}
 #endif
@@ -251,7 +251,7 @@ void server_callback(struct shttpd_arg *arg)
 #ifdef SHTTPD_GSS
 			if (payload) {
 				free(payload);
-				/* note that payload is stiil set - this is used as a flag later */
+				/* note that payload is still set - this is used as a flag later */
 			}
 			else {
 #endif
@@ -356,7 +356,7 @@ DONE:
 	shttpd_printf(arg, "Server: %s/%s\r\n", PACKAGE_NAME, PACKAGE_VERSION);
 #ifdef SHTTPD_GSS
 	if(payload) {
-		// we had an encrypted message so now we have to encypt the reply
+		// we had an encrypted message so now we have to encrypt the reply
 		char *enc;
 		int enclen;
 		if(gss_encrypt(arg, state->response, state->len, &enc, &enclen) != 1) //Not OK
@@ -364,7 +364,7 @@ DONE:
 		u_free(state->response);
 		state->response = enc;
 		state->len = enclen;
-		payload = 0; // and reset the indicator so that if we send in packates we dont do this again
+		payload = 0; // and reset the indicator so that if we send in packets we don't do this again
 		shttpd_printf(arg, "Content-Type: multipart/encrypted;protocol=\"application/HTTP-Kerberos-session-encrypted\";boundary=\"Encrypted Boundary\"\r\n");
 		shttpd_printf(arg, "Content-Length: %d\r\n", state->len);
 	}
@@ -487,7 +487,7 @@ static int initialize_basic_authenticator(void)
 			     wsmand_option_get_basic_authenticator()))) ||
 		    wsmand_option_get_basic_authenticator_arg()) {
 			fprintf(stderr,
-				"basic authentication is ambigious in config file\n");
+				"basic authentication is ambiguous in config file\n");
 			return 1;
 		}
 		auth = wsmand_default_basic_authenticator();
@@ -498,7 +498,7 @@ static int initialize_basic_authenticator(void)
 	}
 
 	if (auth == NULL) {
-		/* No basic authenticationame */
+		/* No basic authentication name */
 		return 0;
 	}
 

--- a/tests/client/test_identify.c
+++ b/tests/client/test_identify.c
@@ -91,7 +91,7 @@ int main(int argc, char** argv)
     client_opt_t *options = NULL;
 
 
-    printf ("Test 1: Testin Identify Request:");
+    printf ("Test 1: Testing Identify Request:");
     cl = wsmc_create( sd[0].server,
         sd[0].port,
         sd[0].path,


### PR DESCRIPTION
Fix trivial spelling errors, mostly in comments and debug
messages.

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>