### PR TITLE
wsman-soap-envelope: fix potential NULL pointer dereference

### DIFF
--- a/src/lib/wsman-soap-envelope.c
+++ b/src/lib/wsman-soap-envelope.c
@@ -955,6 +955,8 @@ void wsman_get_fragment_type(char *fragstr, int *fragment_flag, char **element,
 	*index = 0;
 	if(fragstr == NULL) return;
 	dupstr = u_strdup(fragstr);
+	if (dupstr == NULL)
+		return;
 	p = strstr(dupstr, "/text()");
 	if(p) {
 		*p = '\0';


### PR DESCRIPTION
Bail out if strdup failed.

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>