### PR TITLE
openwsman: cleanup password after use

### DIFF
--- a/include/u/memory.h
+++ b/include/u/memory.h
@@ -16,6 +16,8 @@ void *u_zalloc(size_t sz);
 void *u_calloc(size_t cnt, size_t sz);
 void *u_realloc(void *ptr, size_t sz);
 void u_free(void *ptr);
+void u_cleanfree(char *ptr);
+void u_cleanfreew(wchar_t *ptr);
 
 #ifdef __cplusplus
 }

--- a/src/lib/u/memory.c
+++ b/src/lib/u/memory.c
@@ -6,6 +6,8 @@ static const char rcsid[] =
     "$Id: memory.c,v 1.2 2006/01/09 12:38:38 tat Exp $";
 
 #include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
 
 #include <u/memory.h>
 
@@ -43,6 +45,29 @@ void u_free (void *ptr)
 {
     if (ptr)
         free(ptr);
+}
+
+typedef void* (*memset_t)(void*, int, size_t);
+
+/* To make compiler always execute it */
+static volatile memset_t memset_func = memset;
+
+/** \brief Wrapper for free(3), sanity checks the supplied pointer and cleans memory*/
+void u_cleanfree(char *ptr)
+{
+   if (!ptr)
+      return;
+   memset_func(ptr, strlen(ptr) * sizeof(char), 0);
+   free(ptr);
+}
+
+/** \brief Wrapper for free(3), sanity checks the supplied pointer and cleans memory*/
+void u_cleanfreew(wchar_t *ptr)
+{
+   if (!ptr)
+      return;
+   memset_func(ptr, wcslen(ptr) * sizeof(wchar_t), 0);
+   free(ptr);
 }
 
 /**

--- a/src/lib/wsman-client-transport.c
+++ b/src/lib/wsman-client-transport.c
@@ -177,7 +177,7 @@ char *wsman_transport_get_userName(WsManClient * cl)
 
 void wsman_transport_set_password(WsManClient * cl, const char *arg)
 {
-	u_free(cl->data.pwd);
+	u_cleanfree(cl->data.pwd);
 	cl->data.pwd = arg ? u_strdup(arg) : NULL;
 }
 
@@ -424,7 +424,7 @@ char *wsman_transport_get_proxy_password(WsManClient *cl)
 
 void wsman_transport_set_proxy_password(WsManClient *cl, const char *proxy_password )
 {
-  u_free(cl->proxy_data.proxy_password);
+  u_cleanfree(cl->proxy_data.proxy_password);
   cl->proxy_data.proxy_password = proxy_password ? u_strdup(proxy_password) : NULL;
 }
 

--- a/src/lib/wsman-client.c
+++ b/src/lib/wsman-client.c
@@ -2239,7 +2239,7 @@ wsmc_release(WsManClient * cl)
 	}
 
 	if (cl->data.pwd) {
-		u_free(cl->data.pwd);
+		u_cleanfree(cl->data.pwd);
 		cl->data.pwd = NULL;
 	}
 
@@ -2288,7 +2288,7 @@ wsmc_release(WsManClient * cl)
           cl->proxy_data.proxy_username = NULL;
         }
         if (cl->proxy_data.proxy_password != NULL) {
-          u_free(cl->proxy_data.proxy_password);
+          u_cleanfree(cl->proxy_data.proxy_password);
           cl->proxy_data.proxy_password = NULL;
         }
         pthread_mutex_destroy(&cl->mutex);

--- a/src/lib/wsman-win-client-transport.c
+++ b/src/lib/wsman-win-client-transport.c
@@ -402,7 +402,7 @@ wsmc_handler(WsManClient * cl, WsXmlDocH rqstDoc, void *user_data)
 		}
 		bResults = WinHttpSetOption(request, WINHTTP_OPTION_PROXY_PASSWORD,
 				proxy_password, wcslen(proxy_password));
-		u_free(proxy_password);
+		u_cleanfreew(proxy_password);
 		if (!bResults)
 		{
 			lastErr = GetLastError();
@@ -513,7 +513,7 @@ wsmc_handler(WsManClient * cl, WsXmlDocH rqstDoc, void *user_data)
 					usr = convert_to_unicode(cl->data.user);
 					if ((pwd == NULL) || (usr == NULL)) {
 						if (pwd != NULL) {
-							u_free(pwd);
+							u_cleanfreew(pwd);
 						}
 						if (usr != NULL) {
 							u_free(usr);
@@ -527,7 +527,7 @@ wsmc_handler(WsManClient * cl, WsXmlDocH rqstDoc, void *user_data)
 							dwSelectedScheme,
 							usr, pwd,
 							NULL);
-					u_free(pwd);
+					u_cleanfreew(pwd);
 					u_free(usr);
 				}
 				if (cleanup_request_data(request)) {
@@ -618,7 +618,7 @@ wsmc_handler(WsManClient * cl, WsXmlDocH rqstDoc, void *user_data)
 				usr = convert_to_unicode(cl->data.user);
 				if ((pwd == NULL) || (usr == NULL)) {
 					if (pwd != NULL) {
-						u_free(pwd);
+						u_cleanfreew(pwd);
 					}
 					if (usr != NULL) {
 						u_free(usr);
@@ -632,7 +632,7 @@ wsmc_handler(WsManClient * cl, WsXmlDocH rqstDoc, void *user_data)
 						dwSelectedScheme,
 						usr, pwd,
 						NULL);
-				u_free(pwd);
+				u_cleanfreew(pwd);
 				u_free(usr);
 			}
 			if (cleanup_request_data(request)) {


### PR DESCRIPTION
Secure cleanup connection and proxy passwords after the last use to
eliminate possibility of password leak on memory release.
