### PR TITLE
openwsman: wsman-win-client-transport: initialize certificate pointer

### DIFF
--- a/src/lib/wsman-win-client-transport.c
+++ b/src/lib/wsman-win-client-transport.c
@@ -302,7 +302,7 @@ wsmc_handler(WsManClient * cl, WsXmlDocH rqstDoc, void *user_data)
 	char pszAnsi[128];
 	wchar_t *pwsz;
 
-	PCCERT_CONTEXT certificate;
+	PCCERT_CONTEXT certificate = NULL;
 	wchar_t *proxy_username;
 	wchar_t *proxy_password;
 	if (cl->session_handle == NULL && wsmc_transport_init(cl, NULL)) {


### PR DESCRIPTION
Initialize the certificate pointer to NULL to avoid
warnings about uninitilized variable usage that became
errors with new Visual Studio.

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>