### PR TITLE
openwsman: iniparser: fix buffer size

### DIFF
--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -496,7 +496,8 @@ static int iniparser_add_entry(
     const char * key,
     char * val)
 {
-    char longkey[2*ASCIILINESZ+1];
+    /* two strings, colon and trailing zero */
+    char longkey[2*ASCIILINESZ+2];
 
     /* Make a key as section:keyword */
     if (key!=NULL) {


### PR DESCRIPTION
Account for column size in buffer.

Fix gcc warning:
openwsman/src/lib/u/iniparser.c: In function ‘iniparser_new’:
openwsman/src/lib/u/iniparser.c:503:50: warning: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
  503 |         snprintf(longkey, sizeof(longkey), "%s:%s", sec, key);
      |                                                  ^
In file included from /usr/include/stdio.h:867,
                 from openwsman/src/lib/u/iniparser.c:31:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 2 and 2050 bytes into a destination of size 2049

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>