### PR TITLE
openwsman: wsman-win-client-transport: plug leak in error path

### DIFF
--- a/src/lib/wsman-win-client-transport.c
+++ b/src/lib/wsman-win-client-transport.c
@@ -111,6 +111,7 @@ int wsmc_transport_init(WsManClient *cl, void *arg)
 	while (InterlockedExchange(&cl->lock_session_handle, 1L));
 	if (cl->session_handle != NULL) {
 		cl->lock_session_handle = 0L;
+		u_free(agent);
 		return 0;
 	}
 	if(!cl->proxy_data.proxy){


### PR DESCRIPTION
Free allocated memory in error path.

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>