### PR TITLE
set LD_LIBRARY_PATH for tests

### DIFF
--- a/README.testing
+++ b/README.testing
@@ -43,6 +43,7 @@ Start sblim-sfcb
 ## Running tests
 
 > cd build
+> export LD_LIBRARY_PATH=`pwd`/src/lib
 > make test
 
 Note: When running openwsmand from the local build directory as


### PR DESCRIPTION
Make clear that LD_LIBRARY_PATH must be set when running tests from local (build) directory,

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>