### PR TITLE
Adds Python 3.11 support

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -13,7 +13,7 @@ enable_testing()
 add_subdirectory(tests)
 
 IF( BUILD_PYTHON3 )
-set(Python_ADDITIONAL_VERSIONS 3.10 3.9 3.8 3.7 3.6 3.5 3.4)
+set(Python_ADDITIONAL_VERSIONS 3.11 3.10 3.9 3.8 3.7)
 ELSE( BUILD_PYTHON3 )
 set(Python_ADDITIONAL_VERSIONS 2.7 2.6)
 ENDIF( BUILD_PYTHON3 )

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -13,7 +13,7 @@ enable_testing()
 add_subdirectory(tests)
 
 IF( BUILD_PYTHON3 )
-set(Python_ADDITIONAL_VERSIONS 3.11 3.10 3.9 3.8 3.7)
+set(Python_ADDITIONAL_VERSIONS 3.11 3.10 3.9 3.8)
 ELSE( BUILD_PYTHON3 )
 set(Python_ADDITIONAL_VERSIONS 2.7 2.6)
 ENDIF( BUILD_PYTHON3 )


### PR DESCRIPTION
* Also removes EOL 3.x versions of Python

A couple questions:
* Python 3.7 EOL's in less than four months. Should we remove that too?
* Do we also want to remove all 2.x references?

This work was sponsored by https://metify.io