### PR TITLE
Fix warnings and c++17 compatibility

### DIFF
--- a/src/cpp/Exception.h
+++ b/src/cpp/Exception.h
@@ -14,7 +14,8 @@
 #include <string>
 #include <stdexcept>
 
-using namespace std;
+using std::string;
+using std::exception;
 // Error Codes
 #define WSMAN_SUCCESS 0
 // A general error occurred

--- a/src/cpp/WsmanClient.h
+++ b/src/cpp/WsmanClient.h
@@ -19,7 +19,8 @@
 #include "WsmanFilter.h"
 #include "WsmanOptions.h"
 
-using namespace std;
+using std::string;
+using std::vector;
 using namespace WsmanExceptionNamespace;
 
 namespace WsmanClientNamespace

--- a/src/cpp/WsmanEPR.h
+++ b/src/cpp/WsmanEPR.h
@@ -4,7 +4,7 @@
 #include <string>
 #include "wsman-epr.h"
 
-using namespace std;
+using std::string;
 
 namespace WsmanClientNamespace {
 

--- a/src/cpp/WsmanFilter.h
+++ b/src/cpp/WsmanFilter.h
@@ -6,7 +6,8 @@
 #include <vector>
 #include "wsman-filter.h"
 
-using namespace std;
+using std::string;
+using std::vector;
 typedef std::map<std::string, std::string> NameValuePairs;
 typedef std::map<std::string, std::string>::const_iterator PairsIterator;
 

--- a/src/cpp/WsmanOptions.h
+++ b/src/cpp/WsmanOptions.h
@@ -20,7 +20,7 @@ extern "C" {
 } 
 #include "WsmanFilter.h" // For NameValuePairs
 
-using namespace std;
+using std::string;
 
 namespace WsmanClientNamespace {
 	class WsmanEPR;

--- a/src/lib/wsman-client.c
+++ b/src/lib/wsman-client.c
@@ -91,7 +91,7 @@ wsman_make_action(const char *uri, const char *op_name)
 		char *ptr = (char *)u_malloc(len);
 		if (ptr) {
 			int ret = snprintf(ptr, len, "%s/%s", uri, op_name);
-			if (ret < 0 || ret >= len) {
+			if (ret < 0 || (size_t)ret >= len) {
 				error("Error: formatting action");
 				u_free(ptr);
 				return NULL;

--- a/src/lib/wsman-epr.c
+++ b/src/lib/wsman-epr.c
@@ -374,7 +374,7 @@ int epr_cmp(const epr_t *epr1, const epr_t *epr2)
 
 char *epr_to_string(const epr_t *epr)
 {
-  int len;
+  size_t len;
   char *buf, *ptr;
   unsigned int i;
   key_value_t *p = NULL;

--- a/src/lib/wsman-soap-envelope.c
+++ b/src/lib/wsman-soap-envelope.c
@@ -131,7 +131,7 @@ wsman_create_response_envelope(WsXmlDocH rqstDoc, const char *action)
 				if (tmp && action) {
 					int ret;
 					ret = snprintf(tmp, len, "%s%s", action, WSFW_RESPONSE_STR);
-					if (ret < 0 ||  ret >= len) {
+					if (ret < 0 || (size_t)ret >= len) {
 						u_free(tmp);
 						return NULL;
 					}

--- a/src/lib/wsman-xml.c
+++ b/src/lib/wsman-xml.c
@@ -173,7 +173,7 @@ static char *make_qname(WsXmlNodeH node, const char *uri, const char *name)
 
 		if (prefix != NULL && name != NULL) {
 			int ret = snprintf(buf, len, "%s:%s", prefix, name);
-			if (ret < 0 || ret >= len) {
+			if (ret < 0 || (size_t)ret >= len) {
 				u_free(buf);
 				return NULL;
 			}


### PR DESCRIPTION
Fix part of "signed/unsigned mismatch" warnings.
Specialize "using namespace std;" to ensure c++17 compatibility.