### PR TITLE
Fix incompatible pointer type error with GCC 14.

### DIFF
--- a/bindings/openwsman.i
+++ b/bindings/openwsman.i
@@ -109,7 +109,7 @@ SWIGINTERNINLINE SV *SWIG_From_double  SWIG_PERL_DECL_ARGS_1(double value);
 
 %typemap(in) FILE* {
 #if RUBY_VERSION > 18
-  struct rb_io_t *fptr;
+  struct rb_io *fptr;
 #else
   struct OpenFile *fptr;
 #endif


### PR DESCRIPTION
openwsman fails to build with GCC 14:

```
cd /builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby && /usr/bin/gcc -Drbwsman_EXPORTS -I/builddir/build/BUILD/openwsman-2.7.2/build -I/usr/include/x86_64-linux -I/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby -I/builddir/build/BUILD/openwsman-2.7.2 -I/builddir/build/BUILD/openwsman-2.7.2/bindings -I/builddir/build/BUILD/openwsman-2.7.2/include -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DFEDORA -DNO_SSL_CALLBACK -fPIC -pie -Wl,-z,relro -Wl,-z,now -Wall -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DFEDORA -DNO_SSL_CALLBACK -fno-strict-aliasing -fPIC   -fPIC -MD -MT bindings/ruby/CMakeFiles/rbwsman.dir/openwsman_wrap.c.o -MF CMakeFiles/rbwsman.dir/openwsman_wrap.c.o.d -o CMakeFiles/rbwsman.dir/openwsman_wrap.c.o -c /builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c: In function ‘_wrap_XmlDoc_dump_file’:
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:4049:5: error: assignment to ‘struct rb_io_t *’ from incompatible pointer type ‘struct rb_io *’ [-Wincompatible-pointer-types]
 4049 |     GetOpenFile(argv[0], fptr);
      |     ^~~~~~~~~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:4049:5: error: passing argument 1 of ‘rb_io_check_closed’ from incompatible pointer type [-Wincompatible-pointer-types]
 4049 |     GetOpenFile(argv[0], fptr);
      |     ^~~~~~~~~~~
      |     |
      |     struct rb_io_t *
In file included from /builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:1954:
/usr/include/ruby/io.h:639:34: note: expected ‘rb_io_t *’ {aka ‘struct rb_io *’} but argument is of type ‘struct rb_io_t *’
  639 | void rb_io_check_closed(rb_io_t *fptr);
      |                         ~~~~~~~~~^~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:4052:29: error: passing argument 1 of ‘rb_io_stdio_file’ from incompatible pointer type [-Wincompatible-pointer-types]
 4052 |     arg2 = rb_io_stdio_file(fptr);
      |                             ^~~~
      |                             |
      |                             struct rb_io_t *
/usr/include/ruby/io.h:495:33: note: expected ‘rb_io_t *’ {aka ‘struct rb_io *’} but argument is of type ‘struct rb_io_t *’
  495 | FILE *rb_io_stdio_file(rb_io_t *fptr);
      |                        ~~~~~~~~~^~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c: In function ‘_wrap_XmlNode_dump_file’:
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:4418:5: error: assignment to ‘struct rb_io_t *’ from incompatible pointer type ‘struct rb_io *’ [-Wincompatible-pointer-types]
 4418 |     GetOpenFile(argv[0], fptr);
      |     ^~~~~~~~~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:4418:5: error: passing argument 1 of ‘rb_io_check_closed’ from incompatible pointer type [-Wincompatible-pointer-types]
 4418 |     GetOpenFile(argv[0], fptr);
      |     ^~~~~~~~~~~
      |     |
      |     struct rb_io_t *
/usr/include/ruby/io.h:639:34: note: expected ‘rb_io_t *’ {aka ‘struct rb_io *’} but argument is of type ‘struct rb_io_t *’
  639 | void rb_io_check_closed(rb_io_t *fptr);
      |                         ~~~~~~~~~^~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:4421:29: error: passing argument 1 of ‘rb_io_stdio_file’ from incompatible pointer type [-Wincompatible-pointer-types]
 4421 |     arg2 = rb_io_stdio_file(fptr);
      |                             ^~~~
      |                             |
      |                             struct rb_io_t *
/usr/include/ruby/io.h:495:33: note: expected ‘rb_io_t *’ {aka ‘struct rb_io *’} but argument is of type ‘struct rb_io_t *’
  495 | FILE *rb_io_stdio_file(rb_io_t *fptr);
      |                        ~~~~~~~~~^~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c: In function ‘_wrap_Client_dumpfilee___’:
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:11844:5: error: assignment to ‘struct rb_io_t *’ from incompatible pointer type ‘struct rb_io *’ [-Wincompatible-pointer-types]
11844 |     GetOpenFile(argv[0], fptr);
      |     ^~~~~~~~~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:11844:5: error: passing argument 1 of ‘rb_io_check_closed’ from incompatible pointer type [-Wincompatible-pointer-types]
11844 |     GetOpenFile(argv[0], fptr);
      |     ^~~~~~~~~~~
      |     |
      |     struct rb_io_t *
/usr/include/ruby/io.h:639:34: note: expected ‘rb_io_t *’ {aka ‘struct rb_io *’} but argument is of type ‘struct rb_io_t *’
  639 | void rb_io_check_closed(rb_io_t *fptr);
      |                         ~~~~~~~~~^~~~
/builddir/build/BUILD/openwsman-2.7.2/build/bindings/ruby/openwsman_wrap.c:11847:29: error: passing argument 1 of ‘rb_io_stdio_file’ from incompatible pointer type [-Wincompatible-pointer-types]
11847 |     arg2 = rb_io_stdio_file(fptr);
      |                             ^~~~
      |                             |
      |                             struct rb_io_t *
/usr/include/ruby/io.h:495:33: note: expected ‘rb_io_t *’ {aka ‘struct rb_io *’} but argument is of type ‘struct rb_io_t *’
  495 | FILE *rb_io_stdio_file(rb_io_t *fptr);
      |                        ~~~~~~~~~^~~~
make[2]: Leaving directory '/builddir/build/BUILD/openwsman-2.7.2/build'
make[2]: *** [bindings/ruby/CMakeFiles/rbwsman.dir/build.make:86: bindings/ruby/CMakeFiles/rbwsman.dir/openwsman_wrap.c.o] Error 1
```