### PR TITLE
Fixed prototypes, added a missing header to the install rule, and removed an unused variable.

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,7 +13,7 @@ wsmaninclude_HEADERS = \
 	wsman-client-transport.h \
 	wsman-xml-serializer.h \
 	wsman-xml-serialize.h \
-    	wsman-server-api.h \
+	wsman-server-api.h \
 	wsman-faults.h \
 	wsman-soap-message.h \
 	wsman-api.h \
@@ -24,7 +24,8 @@ wsmaninclude_HEADERS = \
 	wsman-soap-envelope.h \
 	wsman-subscription-repository.h \
 	wsman-event-pool.h \
-	wsman-cimindication-processor.h
+	wsman-cimindication-processor.h \
+	wsman-key-value.h
 
 EXTRA_DIST = wsman-xml.h \
 	     wsman-xml-binding.h \

--- a/src/lib/u/iniparser.c
+++ b/src/lib/u/iniparser.c
@@ -903,7 +903,6 @@ dictionary * iniparser_new(char *ininame)
     char        val[ASCIILINESZ+1];
     char    *   where ;
     FILE    *   ini ;
-    int         lineno ;
 
     if ((ini=fopen(ininame, "r"))==NULL) {
         return NULL ;
@@ -919,9 +918,7 @@ dictionary * iniparser_new(char *ininame)
       fclose(ini);
       return d;
     }
-    lineno = 0 ;
     while (fgets(lin, ASCIILINESZ, ini)!=NULL) {
-        lineno++ ;
         where = strskp(lin); /* Skip leading spaces */
         if (*where==';' || *where=='#' || *where==0)
             continue ; /* Comment lines */

--- a/src/lib/wsman-cimindication-processor.c
+++ b/src/lib/wsman-cimindication-processor.c
@@ -240,7 +240,7 @@ void create_indication_event(WsXmlDocH indoc, WsSubscribeInfo *subsInfo, EventPo
 
 }
 
-CimxmlMessage *cimxml_message_new() {
+CimxmlMessage *cimxml_message_new(void) {
 	CimxmlMessage *cimxml_msg = u_zalloc(sizeof(CimxmlMessage));
 	u_buf_create(&cimxml_msg->request);
 	u_buf_create(&cimxml_msg->response);

--- a/src/lib/wsman-event-pool.c
+++ b/src/lib/wsman-event-pool.c
@@ -53,7 +53,7 @@ struct __EventPoolOpSet event_pool_op_set ={MemEventPoolInit, MemEventPoolFinali
 	MemEventPoolCount, MemEventPoolAddEvent, MemEventPoolAddPullEvent,
 	MemEventPoolGetAndDeleteEvent, MemEventPoolClearEvent};
 
-EventPoolOpSetH wsman_get_eventpool_opset()
+EventPoolOpSetH wsman_get_eventpool_opset(void)
 {
 	return &event_pool_op_set;
 }

--- a/src/lib/wsman-libxml2-binding.c
+++ b/src/lib/wsman-libxml2-binding.c
@@ -111,12 +111,12 @@ myXmlErrorReporting (void *ctx, const char* msg, ...)
 	u_free(string);
 }
 
-void xml_parser_initialize()
+void xml_parser_initialize(void)
 {
 	xmlSetGenericErrorFunc(NULL, myXmlErrorReporting);
 }
 
-void xml_parser_destroy()
+void xml_parser_destroy(void)
 {
 }
 

--- a/src/lib/wsman-soap-message.c
+++ b/src/lib/wsman-soap-message.c
@@ -62,7 +62,7 @@ wsman_set_message_flags(WsmanMessage *msg,
 
 
 WsmanMessage*
-wsman_soap_message_new()
+wsman_soap_message_new(void)
 {
     WsmanMessage *wsman_msg = u_zalloc(sizeof(WsmanMessage));
     if (!wsman_msg)

--- a/src/lib/wsman-soap.c
+++ b/src/lib/wsman-soap.c
@@ -526,7 +526,7 @@ ws_create_context(SoapH soap)
 }
 
 SoapH
-ws_soap_initialize()
+ws_soap_initialize(void)
 {
 	SoapH soap = (SoapH) u_zalloc(sizeof(*soap));
 

--- a/src/lib/wsman-subscription-repository.c
+++ b/src/lib/wsman-subscription-repository.c
@@ -71,7 +71,7 @@ static struct __SubsRepositoryOpSet subscription_repository_op_set = {
 
 static int LocalSubscriptionInitFlag = 0;
 
-SubsRepositoryOpSetH wsman_get_subsrepos_opset()
+SubsRepositoryOpSetH wsman_get_subsrepos_opset(void)
 {
 	return &subscription_repository_op_set;
 }

--- a/src/lib/wsman-xml-serialize.c
+++ b/src/lib/wsman-xml-serialize.c
@@ -72,7 +72,7 @@ struct __WsSerializerContext
 	list_t *WsSerializerAllocList;
 };
 
-WsSerializerContextH ws_serializer_init()
+WsSerializerContextH ws_serializer_init(void)
 {
 	WsSerializerContextH serializercntx = NULL;
 	serializercntx = u_malloc(sizeof(struct __WsSerializerContext));

--- a/src/lib/wsman-xml.c
+++ b/src/lib/wsman-xml.c
@@ -409,14 +409,14 @@ WsXmlDocH ws_xml_clone_and_create_doc(WsXmlDocH doc,
  * @param soap SOAP handle
  * @param nsData Array with namespace data
  */
-int ws_xml_parser_initialize()
+int ws_xml_parser_initialize(void)
 {
 	xml_parser_initialize();
 	return 1;
 }
 
 
-void ws_xml_parser_destroy()
+void ws_xml_parser_destroy(void)
 {
 	xml_parser_destroy();
 }


### PR DESCRIPTION
See commit log.  The applied changes were necessary to allow building on my M2 with Mac OS using the default toolchain.