### PR TITLE
Fix to build with GCC 15.

### DIFF
--- a/src/plugins/swig/src/target_ruby.c
+++ b/src/plugins/swig/src/target_ruby.c
@@ -49,7 +49,7 @@
  */
 
 static VALUE
-load_module()
+load_module(VALUE)
 {
   ruby_script(PLUGIN_FILE);
   return rb_require(PLUGIN_FILE);


### PR DESCRIPTION
Fixes:

/builddir/build/BUILD/openwsman-2.7.2-build/openwsman-2.7.2/src/plugins/swig/ruby/../src/../src/target_ruby.c: In function ‘RbGlobalInitialize’:
/builddir/build/BUILD/openwsman-2.7.2-build/openwsman-2.7.2/src/plugins/swig/ruby/../src/../src/target_ruby.c:136:14: error: passing argument 1 of ‘rb_protect’ from incompatible pointer type [-Wincompatible-pointer-types]
  136 |   rb_protect(load_module, Qnil, &error);
      |              ^~~~~~~~~~~ 
      |              |
      |              VALUE (*)(void) {aka long unsigned int (*)(void)}
In file included from /usr/include/ruby/internal/scan_args.h:38,
                 from /usr/include/ruby/ruby.h:46:
/usr/include/ruby/internal/intern/proc.h:349:26: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
  349 | VALUE rb_protect(VALUE (*func)(VALUE args), VALUE args, int *state);
      |                  ~~~~~~~~^~~~~~~~~~~~~~~~~
/builddir/build/BUILD/openwsman-2.7.2-build/openwsman-2.7.2/src/plugins/swig/ruby/../src/../src/target_ruby.c:52:1: note: ‘load_module’ declared here
   52 | load_module() 
      | ^~~~~~~~~~~
