### PR TITLE
Fix/update for post-quantum cryptography in TLS

### DIFF
--- a/etc/openwsman.conf
+++ b/etc/openwsman.conf
@@ -32,8 +32,12 @@ ipv6 = yes
 
 # the openwsman server certificate file, in .pem format
 ssl_cert_file = /etc/openwsman/servercert.pem
+# the openwsman server certificate fallback file, in .pem format
+#ssl_cert_fallback_file = /etc/openwsman/servercert-fallback.pem
 # the openwsman server private key, in .pem format
 ssl_key_file = /etc/openwsman/serverkey.pem
+# the openwsman server private key fallback, in .pem format
+#ssl_key_fallback_file = /etc/openwsman/serverkey-fallback.pem
 
 # space-separated list of SSL protocols to *dis*able
 # possible values: SSLv2 SSLv3 TLSv1 TLSv1_1 TLSv1_2

--- a/src/server/shttpd/shttpd.c
+++ b/src/server/shttpd/shttpd.c
@@ -1542,9 +1542,9 @@ set_ssl(struct shttpd_ctx *ctx, const char *pem)
 	if (wsmand_options_get_ssl_cert_fallback_file() &&
                     wsmand_options_get_ssl_key_fallback_file()) {
 		if (SSL_CTX_use_certificate_file(CTX, wsmand_options_get_ssl_cert_fallback_file(), SSL_FILETYPE_PEM) != 1)
-			_shttpd_elog(E_LOG, NULL, "cannot open certificate fallback file %s", pem);
+			_shttpd_report_ssl_error("cannot open certificate fallback file", wsmand_options_get_ssl_cert_fallback_file());
 		else if (SSL_CTX_use_PrivateKey_file(CTX, wsmand_options_get_ssl_key_fallback_file(), SSL_FILETYPE_PEM) != 1)
-			_shttpd_elog(E_LOG, NULL, "cannot open fallback PrivateKey %s", pem);
+			_shttpd_report_ssl_error("cannot open fallback PrivateKey", wsmand_options_get_ssl_key_fallback_file());
 		else
 			retval = TRUE;
 	}

--- a/src/server/shttpd/shttpd.c
+++ b/src/server/shttpd/shttpd.c
@@ -1508,7 +1508,6 @@ set_ssl(struct shttpd_ctx *ctx, const char *pem)
 	char *ssl_disabled_protocols = wsmand_options_get_ssl_disabled_protocols();
 	char *ssl_cipher_list = wsmand_options_get_ssl_cipher_list();
 	int		retval = FALSE;
-	EC_KEY*		key;
 
 	/* Load SSL library dynamically */
 	if ((lib = dlopen(SSL_LIB, RTLD_LAZY)) == NULL) {
@@ -1539,11 +1538,15 @@ set_ssl(struct shttpd_ctx *ctx, const char *pem)
 	else
 		retval = TRUE;
 
-	/* This enables ECDH Perfect Forward secrecy. Currently with just the most generic p256 prime curve */
-	key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-	if (key != NULL) {
-		SSL_CTX_set_tmp_ecdh(CTX, key);
-		EC_KEY_free(key);
+	/* Add fall back certificate/key pair */
+	if (wsmand_options_get_ssl_cert_fallback_file() &&
+                    wsmand_options_get_ssl_key_fallback_file()) {
+		if (SSL_CTX_use_certificate_file(CTX, wsmand_options_get_ssl_cert_fallback_file(), SSL_FILETYPE_PEM) != 1)
+			_shttpd_elog(E_LOG, NULL, "cannot open certificate fallback file %s", pem);
+		else if (SSL_CTX_use_PrivateKey_file(CTX, wsmand_options_get_ssl_key_fallback_file(), SSL_FILETYPE_PEM) != 1)
+			_shttpd_elog(E_LOG, NULL, "cannot open fallback PrivateKey %s", pem);
+		else
+			retval = TRUE;
 	}
 
 	while (ssl_disabled_protocols) {

--- a/src/server/wsmand-daemon.c
+++ b/src/server/wsmand-daemon.c
@@ -76,8 +76,10 @@ static int use_ipv6 = 0;
 #endif
 static int use_digest = 0;
 static char *ssl_key_file = NULL;
+static char *ssl_key_fallback_file = NULL;
 static char *service_path = DEFAULT_SERVICE_PATH;
 static char *ssl_cert_file = NULL;
+static char *ssl_cert_fallback_file = NULL;
 static char *ssl_disabled_protocols = NULL;
 static char *ssl_cipher_list = NULL;
 static char *pid_file = DEFAULT_PID_PATH;
@@ -186,7 +188,9 @@ int wsmand_read_config(dictionary * ini)
 	service_path =
 	    iniparser_getstring(ini, "server:service_path", "/wsman");
 	ssl_key_file = iniparser_getstr(ini, "server:ssl_key_file");
+	ssl_key_fallback_file = iniparser_getstr(ini, "server:ssl_key_fallback_file");
 	ssl_cert_file = iniparser_getstr(ini, "server:ssl_cert_file");
+	ssl_cert_fallback_file = iniparser_getstr(ini, "server:ssl_cert_fallback_file");
         ssl_disabled_protocols = iniparser_getstr(ini, "server:ssl_disabled_protocols");
         ssl_cipher_list = iniparser_getstr(ini, "server:ssl_cipher_list");
 	use_ipv4 = iniparser_getboolean(ini, "server:ipv4", 1);
@@ -362,6 +366,16 @@ char *wsmand_options_get_ssl_key_file(void)
 char *wsmand_options_get_ssl_cert_file(void)
 {
 	return ssl_cert_file;
+}
+
+char *wsmand_options_get_ssl_key_fallback_file(void)
+{
+	return ssl_key_fallback_file;
+}
+
+char *wsmand_options_get_ssl_cert_fallback_file(void)
+{
+	return ssl_cert_fallback_file;
 }
 
 char *wsmand_options_get_ssl_disabled_protocols(void)

--- a/src/server/wsmand-daemon.h
+++ b/src/server/wsmand-daemon.h
@@ -76,6 +76,8 @@ int wsmand_options_get_server_port(void);
 int wsmand_options_get_server_ssl_port(void);
 char *wsmand_options_get_ssl_key_file(void);
 char *wsmand_options_get_ssl_cert_file(void);
+char *wsmand_options_get_ssl_key_fallback_file(void);
+char *wsmand_options_get_ssl_cert_fallback_file(void);
 char *wsmand_options_get_ssl_disabled_protocols(void);
 char *wsmand_options_get_ssl_cipher_list(void);
 int wsmand_options_get_digest(void);


### PR DESCRIPTION
Hi,

OpenSSL 3.5 offers post quantum cryptography (PQC) support:
- default TLS keyshares have been changed to offer X25519MLKEM768
- support for PQC algorithms (ML-KEM, ML-DSA and SLH-DSA)

See https://github.com/openssl/openssl/releases for more info.

Additional info can be found in these drafts:
https://datatracker.ietf.org/doc/html/draft-kwiatkowski-tls-ecdhe-mlkem-03
https://datatracker.ietf.org/doc/html/draft-ietf-lamps-dilithium-certificates-07

a)
openwsman DOESN'T use post-quantum key exchange by default if the peer supports it:
```
# openssl s_client  -connect localhost:5986 </dev/null
[...]
Peer signing digest: SHA256
Peer signature type: rsa_pss_rsae_sha256
Peer Temp Key: ECDH, prime256v1, 256 bits
[...]
```

This is because 'EC_KEY_new_by_curve_name()' usage. Patch removes this function, which is deprecated since OpenSSL 3.0 anyway. See https://docs.openssl.org/3.0/man3/EC_KEY_new/

TLS 1.3 and the X25519MLKEM768 key exchange is used by default if the peer supports it then:
```
# openssl s_client  -connect localhost:5986 </dev/null
[...]
Peer signing digest: SHA256
Peer signature type: rsa_pss_rsae_sha256
Negotiated TLS1.3 group: X25519MLKEM768
[...]
```

b)
This change makes 'owsmangencert.sh' generate ML-DSA certificate:
```
# patch /etc/openwsman/owsmangencert.sh << 'EOF'
--- /etc/openwsman/owsmangencert.sh.orig	2025-05-27 00:50:50.131071368 -0400
+++ /etc/openwsman/owsmangencert.sh	2025-05-27 00:52:30.239071368 -0400
@@ -26,7 +26,7 @@
 # certificate is created
 
 openssl req -days 365 $@ -config $CNFFILE \
-  -new -x509 -nodes -out $CERTFILE \
+  -newkey mldsa65 -x509 -nodes -out $CERTFILE \
   -keyout $KEYFILE
 chmod 600 $KEYFILE

EOF
```

If one wants to use a TLS certificate using ML-DSA , then connection works as expected (assuming 'EC_KEY_new_by_curve_name()' was already removed):
```
# openssl x509 -in /etc/openwsman/servercert.pem --text --noout
[...]
Signature Algorithm: ML-DSA-65
[...]
Public Key Algorithm: ML-DSA-65
[...]
# openssl s_client  -connect localhost:5986 -CAfile /etc/openwsman/servercert.pem </dev/null
[...]
Peer signature type: mldsa65
Negotiated TLS1.3 group: X25519MLKEM768
[...]
Verify return code: 0 (ok)
[...]
# echo $?
0
```

But openwsman DOESN'T support an ML-DSA certificate and classic certificate chain (fall back for clients not having access to PQC) at the same time. There's no configuration or option to load more than one certificate in the server. This could be useful and the rest of the patch implements this functionality.